### PR TITLE
New mimes and a few symlinks of existent ones

### DIFF
--- a/Faba/48x48/mimetypes/application-epub+zip.svg
+++ b/Faba/48x48/mimetypes/application-epub+zip.svg
@@ -1,0 +1,1615 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-epub+zip.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="3.6522716"
+     inkscape:cy="50.337385"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient4439">
+      <stop
+         offset="0"
+         style="stop-color:#85b916;stop-opacity:1;"
+         id="stop4441" />
+      <stop
+         offset="1"
+         style="stop-color:#4c680d;stop-opacity:1;"
+         id="stop4443" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4433">
+      <stop
+         offset="0"
+         style="stop-color:#beeb5c;stop-opacity:1;"
+         id="stop4435" />
+      <stop
+         offset="1"
+         style="stop-color:#88b32d;stop-opacity:1;"
+         id="stop4437" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#linearGradient4433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#linearGradient4439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#linearGradient4439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4499"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4496"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4493"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4490"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4487"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4484"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4481"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4478"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4476"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4474"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4348"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4346"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4344"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4342"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4340"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4338"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4336"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4254"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4256"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4260"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4262"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4264"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4266"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient3870"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         style="stop-color:#c01914;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6" />
+      <stop
+         style="stop-color:#d4231e;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-8" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         style="stop-color:#e5523c;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-2" />
+      <stop
+         style="stop-color:#ed8879;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-81" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4636-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-6" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-2"
+       xlink:href="#linearGradient4636-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient4087-4"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-1"
+       id="radialGradient4085-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-8"
+       id="linearGradient3927-9"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-2" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-1"
+       id="radialGradient3015-2-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-3" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-6"
+       id="radialGradient3013-6-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient3092-1-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3090-9-9"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-3" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9"
+       id="linearGradient3087-4-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-6">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3085-9-4"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6"
+       id="linearGradient3077-8-3"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-6" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4"
+       id="radialGradient3075-2-8"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-7" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-1" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-5"
+       id="linearGradient3072-7-5"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3092-7"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3090-8"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3087-8"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3085-8"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3082-2"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3080-1"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3077-6"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3075-3"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-7"
+       id="linearGradient3072-9"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient4043-6"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-6" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-1" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3015-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3013-7"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-8" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-94">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-7" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-69">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-6" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-9">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-89" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-2" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-5" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-5" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-3" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-9" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient3643"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3645"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3647"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3649"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       cx="24.501682"
+       cy="6.6475959"
+       fx="24.501682"
+       fy="6.6475959"
+       r="17.49832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-6"
+       id="linearGradient3661"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128837"
+     y="4.5095215"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1.0;stroke:url(#linearGradient3082);stroke-width:1.01904118000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4445"
+     transform="translate(0,0.39699975)">
+    <path
+       style="opacity:0.2;fill:#000000"
+       inkscape:connector-curvature="0"
+       d="m 25.939169,31.259301 -5.65624,-5.656702 5.65624,-5.6559 1.88557,1.885224 -3.77114,3.770676 1.88545,1.885567 5.65625,-5.655899 -4.92725,-4.927249 c -0.40235,-0.402691 -1.05496,-0.402691 -1.45765,0 l -7.96927,7.969274 c -0.40235,0.402347 -0.40235,1.054955 0,1.457645 l 7.96939,7.969045 c 0.40269,0.402691 1.0553,0.402691 1.45764,0 l 7.96939,-7.969045 c 0.40235,-0.40269 0.40235,-1.055298 0,-1.457645 l -1.15691,-1.156573 -7.54147,7.541582 z"
+       id="path3663" />
+    <path
+       id="path3284"
+       d="m 25.939169,30.25957 -5.65624,-5.656702 5.65624,-5.6559 1.88557,1.885224 -3.77114,3.770676 1.88545,1.885567 5.65625,-5.655899 -4.92725,-4.927249 c -0.40235,-0.402691 -1.05496,-0.402691 -1.45765,0 l -7.96927,7.969274 c -0.40235,0.402347 -0.40235,1.054955 0,1.457645 l 7.96939,7.969045 c 0.40269,0.402691 1.0553,0.402691 1.45764,0 l 7.96939,-7.969045 c 0.40235,-0.40269 0.40235,-1.055298 0,-1.457645 l -1.15691,-1.156573 -7.54147,7.541582 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;fill-opacity:1" />
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-mathematica.svg
+++ b/Faba/48x48/mimetypes/application-mathematica.svg
@@ -1,0 +1,1057 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-mathematica.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="65.997598"
+     inkscape:cy="0.59744863"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#outerBackgroundGradient-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#outerBackgroundGradient"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#outerBackgroundGradient"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         id="stop4351-7"
+         offset="0"
+         style="stop-color:#f5f5f5;stop-opacity:1;" />
+      <stop
+         id="stop4353-81"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         id="stop3864-8-6-2"
+         offset="0"
+         style="stop-color:#e5523c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-6"
+         offset="1"
+         style="stop-color:#ed8879;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         id="stop4351-5"
+         offset="0"
+         style="stop-color:#f5f5f5;stop-opacity:1;" />
+      <stop
+         id="stop4353-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#c01914;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d4231e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3870"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       id="linearGradient4266"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       id="linearGradient4264"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       id="linearGradient4262"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       id="linearGradient4260"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       id="linearGradient4256"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       id="linearGradient4254"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4336"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4344"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4474"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4481"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4487"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4493"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128822"
+     y="-45.490479"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1;stroke:url(#linearGradient3082);stroke-width:1.01904118;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     transform="scale(1,-1)" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <text
+     y="-157.75488"
+     xml:space="preserve"
+     x="116.50684"
+     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+     inkscape:label="context"
+     id="context"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       y="-157.75488"
+       x="116.50684"
+       sodipodi:role="line"
+       id="tspan3933">apps</tspan></text>
+  <text
+     y="-157.75488"
+     xml:space="preserve"
+     x="223.98828"
+     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+     sodipodi:linespacing="125%"
+     inkscape:label="icon-name"
+     id="icon-name"><tspan
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       y="-157.75488"
+       x="223.98828"
+       sodipodi:role="line"
+       id="tspan3937">mathematica</tspan></text>
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect16x16"
+     width="16"
+     height="16"
+     x="517.5"
+     y="-37.5"
+     inkscape:label="16x16" />
+  <rect
+     style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect24x24"
+     width="24"
+     height="24"
+     x="517.5"
+     y="-77.5"
+     inkscape:label="24x24" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect32x32"
+     width="32"
+     height="32"
+     x="517.5"
+     y="-125.5"
+     inkscape:label="32x32" />
+  <rect
+     inkscape:label="22x22"
+     y="-76.5"
+     x="518.5"
+     height="22"
+     width="22"
+     id="rect22x22"
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+  <rect
+     inkscape:label="48x48"
+     y="42.5"
+     x="389.5"
+     height="48"
+     width="48"
+     id="rect48x48"
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect256x256"
+     width="256"
+     height="256"
+     x="117.5"
+     y="-149.5"
+     inkscape:label="256x256" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect64x64"
+     width="64"
+     height="64"
+     x="389.5"
+     y="-37.5"
+     inkscape:label="64x64" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect96x96"
+     width="96"
+     height="96"
+     x="389.5"
+     y="-149.5"
+     inkscape:label="96x96" />
+  <g
+     id="g4520"
+     transform="matrix(0.62068966,0,0,0.62068966,4.0600282,9.327586)">
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
+       d="m 35.62037,11.75 -3.02222,4.85926 -5.4074,-2.28148 0.6074,6.02963 -5.46667,0.99259 4,4.11852 -4.68148,4.42963 6.20741,0.99259 -0.97778,6.28148 5.54074,-2.9037 2.88889,5.48148 2.88889,-5.40741 5.17037,2.75556 L 43.25,31.20185 48.85,30.52036 44.90926,25.83889 48.73148,21.35 43.30926,20.29815 43.79815,14.52037 38.33148,16.66852 35.62037,11.75 z"
+       id="path6338" />
+    <path
+       id="path6318"
+       d="m 35.62037,10.138889 -3.02222,4.85926 -5.4074,-2.28148 0.6074,6.02963 -5.46667,0.99259 4,4.11852 -4.68148,4.42963 6.20741,0.99259 -0.97778,6.28148 5.54074,-2.9037 2.88889,5.48148 2.88889,-5.40741 5.17037,2.75556 -0.11852,-5.8963 5.6,-0.68149 -3.94074,-4.68147 3.82222,-4.48889 -5.42222,-1.05185 0.48889,-5.77778 -5.46667,2.14815 -2.71111,-4.91852 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-vnd.nintendo.snes.rom.svg
+++ b/Faba/48x48/mimetypes/application-vnd.nintendo.snes.rom.svg
@@ -1,0 +1,1133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-vnd.nintendo.snes.rom.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         id="stop4568"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4570"
+         offset="1"
+         style="stop-color:#625c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4149">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4151" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         id="stop4129"
+         offset="0"
+         style="stop-color:#8f2b12;stop-opacity:1;" />
+      <stop
+         id="stop4131"
+         offset="1"
+         style="stop-color:#82461a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4134"
+       id="linearGradient4140"
+       x1="789"
+       y1="256"
+       x2="827"
+       y2="256"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4136" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4138" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4130">
+      <path
+         id="path4132"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5618"
+       id="linearGradient4083"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         style="stop-color:#3e3e3e;stop-opacity:1;"
+         offset="0"
+         id="stop5620" />
+      <stop
+         style="stop-color:#595959;stop-opacity:1;"
+         offset="1"
+         id="stop5622" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         style="stop-color:#dd2f03;stop-opacity:1;"
+         offset="0"
+         id="stop3936" />
+      <stop
+         style="stop-color:#e96300;stop-opacity:1;"
+         offset="1"
+         id="stop3938" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3177"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4149"
+       id="linearGradient4155"
+       x1="24"
+       y1="43.5"
+       x2="37"
+       y2="23.375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0"
+       id="linearGradient3998-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         id="stop4102"
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1;" />
+      <stop
+         id="stop4104"
+         offset="1"
+         style="stop-color:#767676;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4900"
+       gradientUnits="userSpaceOnUse"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         style="stop-color:#cd5fc2;stop-opacity:1;"
+         offset="0"
+         id="stop4086" />
+      <stop
+         style="stop-color:#9a4993;stop-opacity:1;"
+         offset="1"
+         id="stop4088" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         style="stop-color:#717171;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-3" />
+      <stop
+         style="stop-color:#848484;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4904"
+       gradientUnits="userSpaceOnUse"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3415" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3417" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4068">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4070"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4060">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4062"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3423">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3425"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3427">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3429"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3431">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3433"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3435">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3437"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3439">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3441"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3443">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3445"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-231.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-235.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3968"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3958"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3950"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3997"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop5144" />
+      <stop
+         id="stop5146"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5148" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5172"
+       xlink:href="#linearGradient3944"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4202"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="translate(-4.0000003,0)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3928">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         id="path3930"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(389,-66)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#a4a4a4;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#e6e6e6;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3523"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3505">
+      <stop
+         id="stop3507"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3509"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3491">
+      <stop
+         id="stop3493"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3495"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3477">
+      <stop
+         id="stop3479"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3481"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3463">
+      <stop
+         id="stop3465"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3467"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3449">
+      <stop
+         id="stop3451"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3453"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3435">
+      <stop
+         id="stop3437"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3439"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3421">
+      <stop
+         id="stop3423"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3425"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3407">
+      <stop
+         id="stop3409"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3411"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         id="stop3395"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3397"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3379">
+      <stop
+         id="stop3381"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3383"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3365">
+      <stop
+         id="stop3367"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3369"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3860">
+      <stop
+         id="stop3862"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3864"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3852">
+      <stop
+         id="stop3854"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3856"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="28"
+       x2="272"
+       y1="284"
+       x1="272"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4025"
+       xlink:href="#linearGradient3852"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-83">
+      <stop
+         id="stop3864-8-6-1"
+         offset="0"
+         style="stop-color:#03688e;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-40"
+         offset="1"
+         style="stop-color:#2396c1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3860-0">
+      <stop
+         id="stop3862-2"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3864-3"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3852-1"
+       id="linearGradient4032-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-486.7,52.15889)"
+       x1="272"
+       y1="284"
+       x2="272"
+       y2="28" />
+    <linearGradient
+       id="linearGradient3852-1">
+      <stop
+         id="stop3854-9"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3856-8"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3987"
+       d="m 42.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4205);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4214);fill-opacity:1;stroke:none"
+       d="m 42,42 0,3 0.5,0 C 43.331,45 44,44.331 44,43.5 44,42.669 43.331,42 42.5,42 L 42,42 z"
+       id="rect3940"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3989"
+       d="M 4.4866072,41.000001 C 3.6630268,41.000001 3,42.045313 3,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4202);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4211);fill-opacity:1;stroke:none"
+       d="m 5.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+       id="rect3942"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4208);fill-opacity:1;stroke:none"
+       d="m 5.1141432,41 37.7717148,0 0,5 -37.7717148,0 z"
+       id="rect3985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+       d="m 5.9998568,42 36.0002842,0 0,3 -36.0002842,0 z"
+       id="rect3938"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient3877);fill-opacity:1.0;stroke:none;display:inline"
+       d="M 6.4375 5 C 5.625551 5 5 5.6255532 5 6.4375 L 5 41.5625 C 5 42.374447 5.625551 43 6.4375 43 L 41.5625 43 C 42.374449 43 43 42.374447 43 41.5625 L 43 6.4375 C 43 5.6255532 42.374449 5 41.5625 5 L 6.4375 5 z "
+       id="rect4073" />
+    <rect
+       style="opacity:0.41;fill:none;stroke:#000000;stroke-opacity:1;display:inline"
+       id="rect4085"
+       width="39"
+       height="39"
+       x="-43.5"
+       y="-43.5"
+       transform="matrix(0,-1,-1,0,0,0)"
+       ry="1.95"
+       rx="1.9499974" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.14999999999999999;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       d="M 6.4375,5.00002 C 5.62555,5.00002 5,5.62557 5,6.43752 l 0,1 C 5,6.62557 5.62555,6.00002 6.4375,6.00002 l 35.125,0 c 0.81195,0 1.4375,0.62555 1.4375,1.4375 l 0,-1 c 0,-0.81195 -0.62555,-1.4375 -1.4375,-1.4375 l -35.125,0 z"
+       id="rect4089-4" />
+    <path
+       transform="matrix(0,1,-1,0,280,-784)"
+       style="opacity:0.10000000000000001;fill:none;stroke:url(#linearGradient4140);stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+       id="path4128"
+       clip-path="url(#clipPath4130)"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4105"
+       d="M 6.4375,43.000017 C 5.62555,43.000017 5,42.374417 5,41.562517 L 5,40.56252 c 0,0.811897 0.62555,1.437497 1.4375,1.437497 l 35.125,0 c 0.81195,0 1.4375,-0.6256 1.4375,-1.437497 l 0,0.999997 c 0,0.8119 -0.62555,1.4375 -1.4375,1.4375 l -35.125,0 z"
+       style="opacity:0.10000000000000001;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-758.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-144.75488"
+         x="-758.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-651.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-144.75488"
+         x="-651.01172"
+         sodipodi:role="line"
+         id="tspan3937">zsnes</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-357.5"
+       y="-24.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-357.5"
+       y="-64.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-357.5"
+       y="-112.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-63.5"
+       x="-356.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="55.5"
+       x="-485.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-757.5"
+       y="-136.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-485.5"
+       y="-24.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-485.5"
+       y="-136.5"
+       inkscape:label="96x96" />
+    <g
+       id="g4996"
+       transform="translate(54.5,0)">
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new"
+         d="m -32.375,15.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.06361,-0.0037 0.150305,0 0.21875,0 2.717154,0 4.90625,2.214636 4.90625,4.9375 l 0,0.0625 0.25,-0.03125 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 L -30.5,25 l 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.125 0.21875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 0.1875,-0.125 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.1875 0.15625,-0.1875 0.15625,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.03125,-0.25 0.0625,-0.21875 0.03125,-0.25 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0624,-0.0037 0.123345,0 0.1875,0 2.643202,0 4.8125,2.132867 4.8125,4.78125 l 0,0.0625 0.21875,0 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.125 0.1875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 L -19,28.75 l 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.15625 0.125,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.0625,-0.1875 0.0625,-0.25 0.0625,-0.21875 L -17.5625,26 l 0.03125,-0.25 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,23.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,1.454963 2.324162,2.625 5.1875,2.625 2.867499,0 5.1875,-1.170037 5.1875,-2.625 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,1.523045 2.42727,2.75 5.4375,2.75 C -25.46008,34 -23,32.772349 -23,31.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         id="path4221"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4212"
+         d="m -32.375,14.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.06361,-0.0037 0.150305,0 0.21875,0 2.717154,0 4.90625,2.214636 4.90625,4.9375 l 0,0.0625 0.25,-0.03125 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 L -30.5,24 l 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.125 0.21875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 0.1875,-0.125 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.1875 0.15625,-0.1875 0.15625,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.03125,-0.25 0.0625,-0.21875 0.03125,-0.25 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0624,-0.0037 0.123345,0 0.1875,0 2.643202,0 4.8125,2.132867 4.8125,4.78125 l 0,0.0625 0.21875,0 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.125 0.1875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 L -19,27.75 l 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.15625 0.125,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.0625,-0.1875 0.0625,-0.25 0.0625,-0.21875 L -17.5625,25 l 0.03125,-0.25 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,22.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,1.454963 2.324162,2.625 5.1875,2.625 2.867499,0 5.1875,-1.170037 5.1875,-2.625 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,1.523045 2.42727,2.75 5.4375,2.75 C -25.46008,33 -23,31.772349 -23,30.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;fill:#bbbbbb;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4223"
+         d="m -32.375,14.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.03635,-0.0021 0.08129,-6.47e-4 0.125,0 0.449995,-2.057987 2.179304,-3.629072 4.3125,-3.84375 0.164365,-0.01654 0.331272,0 0.5,0 2.547993,0 4.65244,1.926511 4.90625,4.40625 l 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0312,-0.0019 0.06269,-4.63e-4 0.09375,0 0.48043,-2.1494 2.431506,-3.75 4.71875,-3.75 2.50088,0 4.528315,1.93225 4.75,4.375 l 0,-0.09375 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,22.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,0.171172 0.03232,0.338156 0.09375,0.5 l 0.0625,-0.15625 0.0625,-0.125 L -43.1875,25.5 -43.09375,25.375 -43,25.25 l 0.125,-0.125 0.125,-0.09375 0.125,-0.09375 0.15625,-0.125 0.15625,-0.09375 0.15625,-0.09375 0.1875,-0.09375 0.15625,-0.09375 0.1875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.25,-0.03125 0.25,-0.0625 0.21875,-0.03125 0.25,-0.03125 0.28125,-0.03125 0.25,0 0.25,0 0.28125,-0.03125 c 2.509671,0 4.610607,0.89757 5.09375,2.09375 0.05407,-0.152354 0.09375,-0.308276 0.09375,-0.46875 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,0.149131 0.04894,0.29492 0.09375,0.4375 l 0.0625,-0.125 0.09375,-0.125 0.0625,-0.125 0.09375,-0.125 0.125,-0.125 0.125,-0.125 0.125,-0.125 0.15625,-0.09375 0.125,-0.125 0.1875,-0.09375 0.15625,-0.09375 0.1875,-0.09375 0.1875,-0.09375 0.1875,-0.09375 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.25,-0.03125 0.25,-0.0625 0.25,-0.03125 0.25,-0.03125 0.28125,-0.03125 0.28125,-0.03125 0.25,-0.03125 0.28125,0 0.28125,0 c 2.676463,0 4.91245,0.962935 5.375,2.25 C -23.03634,30.590349 -23,30.418093 -23,30.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-gba-rom.svg
+++ b/Faba/48x48/mimetypes/application-x-gba-rom.svg
@@ -1,0 +1,1214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-gba-rom.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         id="stop4568"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4570"
+         offset="1"
+         style="stop-color:#625c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4149">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4151" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         id="stop4129"
+         offset="0"
+         style="stop-color:#8f2b12;stop-opacity:1;" />
+      <stop
+         id="stop4131"
+         offset="1"
+         style="stop-color:#82461a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4134"
+       id="linearGradient4140"
+       x1="789"
+       y1="256"
+       x2="827"
+       y2="256"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4136" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4138" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4130">
+      <path
+         id="path4132"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5618"
+       id="linearGradient4083"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         style="stop-color:#3e3e3e;stop-opacity:1;"
+         offset="0"
+         id="stop5620" />
+      <stop
+         style="stop-color:#595959;stop-opacity:1;"
+         offset="1"
+         id="stop5622" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         style="stop-color:#dd2f03;stop-opacity:1;"
+         offset="0"
+         id="stop3936" />
+      <stop
+         style="stop-color:#e96300;stop-opacity:1;"
+         offset="1"
+         id="stop3938" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3177"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4149"
+       id="linearGradient4155"
+       x1="24"
+       y1="43.5"
+       x2="37"
+       y2="23.375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0"
+       id="linearGradient3998-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         id="stop4102"
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1;" />
+      <stop
+         id="stop4104"
+         offset="1"
+         style="stop-color:#767676;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4900"
+       gradientUnits="userSpaceOnUse"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         style="stop-color:#cd5fc2;stop-opacity:1;"
+         offset="0"
+         id="stop4086" />
+      <stop
+         style="stop-color:#9a4993;stop-opacity:1;"
+         offset="1"
+         id="stop4088" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         style="stop-color:#717171;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-3" />
+      <stop
+         style="stop-color:#848484;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4904"
+       gradientUnits="userSpaceOnUse"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3415" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3417" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4068">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4070"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4060">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4062"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3423">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3425"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3427">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3429"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3431">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3433"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3435">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3437"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3439">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3441"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3443">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3445"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-231.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-235.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3968"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3958"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3950"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3997"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop5144" />
+      <stop
+         id="stop5146"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5148" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5172"
+       xlink:href="#linearGradient3944"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4202"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="translate(-4.0000003,0)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3928">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         id="path3930"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-09"
+       id="linearGradient5057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient4868">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4870" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4872" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4861">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4863" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4854">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4856" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4858" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4847">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4849" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4851" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4840">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4842" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4844" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4833">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4835" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4837" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3911">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop3913" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop3915" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-09">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#493479;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-16"
+         offset="1"
+         style="stop-color:#6b559e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-5"
+       xlink:href="#outerBackgroundGradient-09"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-1"
+         offset="0"
+         style="stop-color:#4c4c4c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-7"
+         offset="1"
+         style="stop-color:#737373;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4708"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4710"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4704"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4706"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4700"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4702"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4696"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4698"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4692"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4694"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4688"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4690"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4684"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4686"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4680"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4682"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4676"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4678"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath3246-2"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3248-9"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4670"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4672"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4666"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4668"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4662"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4664"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath3246"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3248"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#313131;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#535353;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-7"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         id="stop3864-8-6-7"
+         offset="0"
+         style="stop-color:#6da563;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-5-9"
+         offset="1"
+         style="stop-color:#84cc76;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3911"
+       id="linearGradient4121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66668359,0,0,0.66668359,-263.83842,-85.169899)"
+       x1="320"
+       y1="156"
+       x2="320"
+       y2="188" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3987"
+       d="m 42.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4205);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4214);fill-opacity:1;stroke:none"
+       d="m 42,42 0,3 0.5,0 C 43.331,45 44,44.331 44,43.5 44,42.669 43.331,42 42.5,42 L 42,42 z"
+       id="rect3940"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3989"
+       d="M 4.4866072,41.000001 C 3.6630268,41.000001 3,42.045313 3,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4202);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4211);fill-opacity:1;stroke:none"
+       d="m 5.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+       id="rect3942"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4208);fill-opacity:1;stroke:none"
+       d="m 5.1141432,41 37.7717148,0 0,5 -37.7717148,0 z"
+       id="rect3985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+       d="m 5.9998568,42 36.0002842,0 0,3 -36.0002842,0 z"
+       id="rect3938"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient3877);fill-opacity:1.0;stroke:none;display:inline"
+       d="M 6.4375 5 C 5.625551 5 5 5.6255532 5 6.4375 L 5 41.5625 C 5 42.374447 5.625551 43 6.4375 43 L 41.5625 43 C 42.374449 43 43 42.374447 43 41.5625 L 43 6.4375 C 43 5.6255532 42.374449 5 41.5625 5 L 6.4375 5 z "
+       id="rect4073" />
+    <rect
+       style="opacity:0.41;fill:none;stroke:#000000;stroke-opacity:1;display:inline"
+       id="rect4085"
+       width="39"
+       height="39"
+       x="-43.5"
+       y="-43.5"
+       transform="matrix(0,-1,-1,0,0,0)"
+       ry="1.95"
+       rx="1.9499974" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.14999999999999999;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       d="M 6.4375,5.00002 C 5.62555,5.00002 5,5.62557 5,6.43752 l 0,1 C 5,6.62557 5.62555,6.00002 6.4375,6.00002 l 35.125,0 c 0.81195,0 1.4375,0.62555 1.4375,1.4375 l 0,-1 c 0,-0.81195 -0.62555,-1.4375 -1.4375,-1.4375 l -35.125,0 z"
+       id="rect4089-4" />
+    <path
+       transform="matrix(0,1,-1,0,280,-784)"
+       style="opacity:0.10000000000000001;fill:none;stroke:url(#linearGradient4140);stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+       id="path4128"
+       clip-path="url(#clipPath4130)"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4105"
+       d="M 6.4375,43.000017 C 5.62555,43.000017 5,42.374417 5,41.562517 L 5,40.56252 c 0,0.811897 0.62555,1.437497 1.4375,1.437497 l 35.125,0 c 0.81195,0 1.4375,-0.6256 1.4375,-1.437497 l 0,0.999997 c 0,0.8119 -0.62555,1.4375 -1.4375,1.4375 l -35.125,0 z"
+       style="opacity:0.10000000000000001;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-85.754883"
+       xml:space="preserve"
+       x="-756.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-85.754883"
+         x="-756.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-85.754883"
+       xml:space="preserve"
+       x="-649.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-85.754883"
+         x="-649.01172"
+         sodipodi:role="line"
+         id="tspan3937">gba</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-355.5"
+       y="34.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-355.5"
+       y="-5.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-355.5"
+       y="-53.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-4.5"
+       x="-354.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="114.5"
+       x="-483.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-755.5"
+       y="-77.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-483.5"
+       y="34.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-483.5"
+       y="-77.5"
+       inkscape:label="96x96" />
+    <g
+       id="g5011"
+       transform="translate(41,-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4240"
+         d="M -19.65625,18 C -20.394928,18 -21,18.605051 -21,19.34375 L -21,27 -28.65625,27 C -29.394949,27 -30,27.605072 -30,28.34375 l 0,5.3125 C -30,34.394928 -29.394949,35 -28.65625,35 L -21,35 l 0,7.65625 C -21,43.394949 -20.394928,44 -19.65625,44 l 5.34375,0 C -13.573822,44 -13,43.394949 -13,42.65625 L -13,35 l 7.6874997,0 c 0.738699,0 1.3125,-0.605072 1.3125,-1.34375 l 0,-5.3125 c 0,-0.738678 -0.573801,-1.34375 -1.3125,-1.34375 L -13,27 -13,19.34375 C -13,18.605051 -13.573822,18 -14.3125,18 l -5.34375,0 z M -19,21 l 4,0 -2,4 -2,-4 z m -8,8 4,2 -4,2 0,-4 z m 10,0 c 1.104598,0 2,0.895402 2,2 0,1.104598 -0.895402,2 -2,2 -1.104598,0 -2,-0.895402 -2,-2 0,-1.104598 0.895402,-2 2,-2 z m 9.9999997,0 0,4 L -11,31 -7.0000003,29 z M -17,37 l 2,4 -4,0 2,-4 z"
+         style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         style="color:#000000;fill:#bbbbbb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="M -19.65625,17 C -20.394928,17 -21,17.605051 -21,18.34375 L -21,26 -28.65625,26 C -29.394949,26 -30,26.605072 -30,27.34375 l 0,5.3125 C -30,33.394928 -29.394949,34 -28.65625,34 L -21,34 l 0,7.65625 C -21,42.394949 -20.394928,43 -19.65625,43 l 5.34375,0 C -13.573822,43 -13,42.394949 -13,41.65625 L -13,34 l 7.6874997,0 c 0.738699,0 1.3125,-0.605072 1.3125,-1.34375 l 0,-5.3125 c 0,-0.738678 -0.573801,-1.34375 -1.3125,-1.34375 L -13,26 -13,18.34375 C -13,17.605051 -13.573822,17 -14.3125,17 l -5.34375,0 z M -19,20 l 4,0 -2,4 -2,-4 z m -8,8 4,2 -4,2 0,-4 z m 10,0 c 1.104598,0 2,0.895402 2,2 0,1.104598 -0.895402,2 -2,2 -1.104598,0 -2,-0.895402 -2,-2 0,-1.104598 0.895402,-2 2,-2 z m 9.9999997,0 0,4 L -11,30 -7.0000003,28 z M -17,36 l 2,4 -4,0 2,-4 z"
+         id="path4238"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4227"
+         d="M -19.65625,17 C -20.394928,17 -21,17.605051 -21,18.34375 l 0,1 C -21,18.605051 -20.394928,18 -19.65625,18 l 5.34375,0 C -13.573822,18 -13,18.605051 -13,19.34375 l 0,-1 C -13,17.605051 -13.573822,17 -14.3125,17 l -5.34375,0 z M -19,21 l 2,4 2,-4 -0.5,0 -1.5,3 -1.5,-3 -0.5,0 z m -9.65625,5 C -29.394949,26 -30,26.605072 -30,27.34375 l 0,1 C -30,27.605072 -29.394949,27 -28.65625,27 L -21,27 l 0,-1 -7.65625,0 z M -13,26 l 0,1 7.6875,0 C -4.573801,27 -4,27.605072 -4,28.34375 l 0,-1 C -4,26.605072 -4.573801,26 -5.3125,26 L -13,26 z m -11,4.5 -3,1.5 0,1 4,-2 -1,-0.5 z m 5.0625,0 C -18.978603,30.659761 -19,30.827407 -19,31 c 0,1.104598 0.895402,2 2,2 1.104598,0 2,-0.895402 2,-2 0,-0.172593 -0.0214,-0.340239 -0.0625,-0.5 -0.221957,0.86271 -1.005495,1.5 -1.9375,1.5 -0.932005,0 -1.715543,-0.63729 -1.9375,-1.5 z m 8.9375,0 -1,0.5 4,2 0,-1 -3,-1.5 z m -8.5,9.5 -0.5,1 4,0 -0.5,-1 -3,0 z"
+         style="opacity:0.1;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-mobipocket-ebook.svg
+++ b/Faba/48x48/mimetypes/application-x-mobipocket-ebook.svg
@@ -1,0 +1,2140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-mobipocket-ebook.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="-191.94838"
+     inkscape:cy="83.470291"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient4439">
+      <stop
+         offset="0"
+         style="stop-color:#85b916;stop-opacity:1;"
+         id="stop4441" />
+      <stop
+         offset="1"
+         style="stop-color:#4c680d;stop-opacity:1;"
+         id="stop4443" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4433">
+      <stop
+         offset="0"
+         style="stop-color:#beeb5c;stop-opacity:1;"
+         id="stop4435" />
+      <stop
+         offset="1"
+         style="stop-color:#88b32d;stop-opacity:1;"
+         id="stop4437" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4499"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4496"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4493"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4490"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4487"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4484"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4481"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4478"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4476"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4474"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4348"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4346"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4344"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4342"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4340"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4338"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4336"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4254"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4256"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4260"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4262"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4264"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4266"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient3870"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         style="stop-color:#c01914;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6" />
+      <stop
+         style="stop-color:#d4231e;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-8" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         style="stop-color:#e5523c;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-2" />
+      <stop
+         style="stop-color:#ed8879;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-81" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4636-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-6" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-2"
+       xlink:href="#linearGradient4636-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient4087-4"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-1"
+       id="radialGradient4085-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-8"
+       id="linearGradient3927-9"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-2" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-1"
+       id="radialGradient3015-2-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-3" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-6"
+       id="radialGradient3013-6-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient3092-1-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3090-9-9"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-3" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9"
+       id="linearGradient3087-4-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-6">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3085-9-4"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6"
+       id="linearGradient3077-8-3"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-6" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4"
+       id="radialGradient3075-2-8"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-7" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-1" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-5"
+       id="linearGradient3072-7-5"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3092-7"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3090-8"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3087-8"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3085-8"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3082-2"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3080-1"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3077-6"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3075-3"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-7"
+       id="linearGradient3072-9"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient4043-6"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-6" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-1" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3015-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3013-7"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-8" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-94">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-7" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-69">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-6" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-9">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-89" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-2" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-5" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-5" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-3" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-9" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient3643"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3645"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3647"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3649"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       cx="24.501682"
+       cy="6.6475959"
+       fx="24.501682"
+       fy="6.6475959"
+       r="17.49832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-6"
+       id="linearGradient3661"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-2"
+       id="linearGradient3993-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-0" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-6"
+       xlink:href="#linearGradient4636-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-4"
+       id="linearGradient4087-3"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-6"
+       id="radialGradient4085-5"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-1"
+       id="linearGradient3927-0"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-5" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-21" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-2"
+       id="radialGradient3015-2-1"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-02" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-8"
+       id="radialGradient3013-6-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-4"
+       id="linearGradient3092-1-02"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-9"
+       id="linearGradient3090-9-7"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-0"
+       id="linearGradient3087-4-1"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-9"
+       id="linearGradient3085-9-3"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-4">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-7" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-6">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-0" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-4" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-0"
+       id="linearGradient3077-8-2"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-7">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-7"
+       id="radialGradient3075-2-4"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-6" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-5" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-03" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-2"
+       id="linearGradient3072-7-7"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-5"
+       id="linearGradient3092-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-7"
+       id="linearGradient3090-97"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-0"
+       id="linearGradient3087-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-7"
+       id="linearGradient3085-7"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-5"
+       id="linearGradient3082-27"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-92"
+       id="radialGradient3080-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-82"
+       id="linearGradient3077-7"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-9"
+       id="radialGradient3075-7"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-0"
+       id="linearGradient3072-8"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-2"
+       id="linearGradient4043-3"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-35" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-81">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-81"
+       id="radialGradient3015-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-4">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-8" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-65" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-4"
+       id="radialGradient3013-73"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-6" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-33" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-7">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-5">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-8" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-92">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-11" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-82">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-1" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-1" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-0" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-0">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-8" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-91" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-6" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128837"
+     y="4.5095215"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1.0;stroke:url(#linearGradient3082);stroke-width:1.01904118000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     style="fill:#000000;fill-opacity:1;opacity:0.2"
+     transform="matrix(0.03718204,0,0,0.03718204,16.42073,16.643264)"
+     id="g4458">
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g4460" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;display:inline"
+       d="m 293.596,233.97 c 0,26.322 0.627,48.264 -12.651,71.65 -10.724,19.022 -27.791,30.698 -46.749,30.698 -25.905,0 -41.069,-19.73 -41.069,-48.979 0,-57.525 51.607,-67.983 100.469,-67.983 v 14.614 z m 68.105,164.685 c -4.48,4.005 -10.934,4.283 -15.971,1.567 -22.446,-18.64 -26.462,-27.263 -38.718,-45.009 -37.07,37.767 -63.335,49.094 -111.356,49.094 -56.871,0 -101.09,-35.085 -101.09,-105.269 0,-54.833 29.688,-92.112 72.023,-110.394 36.647,-16.086 87.836,-19.004 127.006,-23.397 v -8.774 c 0,-16.074 1.253,-35.091 -8.218,-48.979 -8.217,-12.43 -24.013,-17.542 -37.905,-17.542 -25.76,0 -48.67,13.196 -54.288,40.552 -1.178,6.094 -5.612,12.11 -11.745,12.425 l -65.459,-7.092 c -5.524,-1.241 -11.676,-5.682 -10.074,-14.119 C 120.942,42.297 192.668,18.3 256.943,18.3 c 32.857,0 75.823,8.774 101.729,33.63 32.857,30.71 29.7,71.65 29.7,116.248 v 105.223 c 0,31.65 13.138,45.543 25.487,62.615 4.317,6.128 5.292,13.44 -0.209,17.92 -13.8,11.571 -38.324,32.869 -51.811,44.87 l -0.138,-0.151 z m 92.56,18.722 c -62.721,26.602 -130.884,39.461 -192.884,39.461 -91.933,0 -180.924,-25.209 -252.882,-67.096 -6.302,-3.668 -10.968,2.797 -5.733,7.532 66.702,60.236 154.845,96.425 252.732,96.425 69.846,0 150.949,-21.971 206.903,-63.254 9.249,-6.847 1.323,-17.084 -8.136,-13.068 z m 16.701,50.278 c -2.043,5.106 2.345,7.172 6.964,3.296 30.014,-25.116 37.767,-77.716 31.615,-85.317 -6.093,-7.532 -58.565,-14.021 -90.599,8.461 -4.921,3.481 -4.062,8.24 1.394,7.59 18.036,-2.17 58.182,-6.986 65.343,2.183 7.149,9.168 -7.962,46.911 -14.717,63.787 z"
+       id="path4462" />
+  </g>
+  <g
+     id="7935ec95c421cee6d86eb22ecd1149e3"
+     transform="matrix(0.03718204,0,0,0.03718204,16.42073,15.643533)"
+     style="fill:#ffffff;fill-opacity:1">
+    <g
+       id="g3434"
+       style="fill:#ffffff;fill-opacity:1" />
+    <path
+       id="path3436"
+       d="m 293.596,233.97 c 0,26.322 0.627,48.264 -12.651,71.65 -10.724,19.022 -27.791,30.698 -46.749,30.698 -25.905,0 -41.069,-19.73 -41.069,-48.979 0,-57.525 51.607,-67.983 100.469,-67.983 v 14.614 z m 68.105,164.685 c -4.48,4.005 -10.934,4.283 -15.971,1.567 -22.446,-18.64 -26.462,-27.263 -38.718,-45.009 -37.07,37.767 -63.335,49.094 -111.356,49.094 -56.871,0 -101.09,-35.085 -101.09,-105.269 0,-54.833 29.688,-92.112 72.023,-110.394 36.647,-16.086 87.836,-19.004 127.006,-23.397 v -8.774 c 0,-16.074 1.253,-35.091 -8.218,-48.979 -8.217,-12.43 -24.013,-17.542 -37.905,-17.542 -25.76,0 -48.67,13.196 -54.288,40.552 -1.178,6.094 -5.612,12.11 -11.745,12.425 l -65.459,-7.092 c -5.524,-1.241 -11.676,-5.682 -10.074,-14.119 C 120.942,42.297 192.668,18.3 256.943,18.3 c 32.857,0 75.823,8.774 101.729,33.63 32.857,30.71 29.7,71.65 29.7,116.248 v 105.223 c 0,31.65 13.138,45.543 25.487,62.615 4.317,6.128 5.292,13.44 -0.209,17.92 -13.8,11.571 -38.324,32.869 -51.811,44.87 l -0.138,-0.151 z m 92.56,18.722 c -62.721,26.602 -130.884,39.461 -192.884,39.461 -91.933,0 -180.924,-25.209 -252.882,-67.096 -6.302,-3.668 -10.968,2.797 -5.733,7.532 66.702,60.236 154.845,96.425 252.732,96.425 69.846,0 150.949,-21.971 206.903,-63.254 9.249,-6.847 1.323,-17.084 -8.136,-13.068 z m 16.701,50.278 c -2.043,5.106 2.345,7.172 6.964,3.296 30.014,-25.116 37.767,-77.716 31.615,-85.317 -6.093,-7.532 -58.565,-14.021 -90.599,8.461 -4.921,3.481 -4.062,8.24 1.394,7.59 18.036,-2.17 58.182,-6.986 65.343,2.183 7.149,9.168 -7.962,46.911 -14.717,63.787 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-python-bytecode.svg
+++ b/Faba/48x48/mimetypes/application-x-python-bytecode.svg
@@ -1,0 +1,1263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-python-bytecode.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="-52.324991"
+     inkscape:cy="23.503429"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         id="stop4568"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4570"
+         offset="1"
+         style="stop-color:#625c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4149">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4151" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         id="stop4129"
+         offset="0"
+         style="stop-color:#8f2b12;stop-opacity:1;" />
+      <stop
+         id="stop4131"
+         offset="1"
+         style="stop-color:#82461a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4134"
+       id="linearGradient4140"
+       x1="789"
+       y1="256"
+       x2="827"
+       y2="256"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4136" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4138" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4130">
+      <path
+         id="path4132"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5618"
+       id="linearGradient4083"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         style="stop-color:#3e3e3e;stop-opacity:1;"
+         offset="0"
+         id="stop5620" />
+      <stop
+         style="stop-color:#595959;stop-opacity:1;"
+         offset="1"
+         id="stop5622" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         style="stop-color:#dd2f03;stop-opacity:1;"
+         offset="0"
+         id="stop3936" />
+      <stop
+         style="stop-color:#e96300;stop-opacity:1;"
+         offset="1"
+         id="stop3938" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3177"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4149"
+       id="linearGradient4155"
+       x1="24"
+       y1="43.5"
+       x2="37"
+       y2="23.375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0"
+       id="linearGradient3998-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         id="stop4102"
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1;" />
+      <stop
+         id="stop4104"
+         offset="1"
+         style="stop-color:#767676;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4900"
+       gradientUnits="userSpaceOnUse"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         style="stop-color:#cd5fc2;stop-opacity:1;"
+         offset="0"
+         id="stop4086" />
+      <stop
+         style="stop-color:#9a4993;stop-opacity:1;"
+         offset="1"
+         id="stop4088" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         style="stop-color:#717171;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-3" />
+      <stop
+         style="stop-color:#848484;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4904"
+       gradientUnits="userSpaceOnUse"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3415" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3417" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4068">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4070"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4060">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4062"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3423">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3425"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3427">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3429"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3431">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3433"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3435">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3437"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3439">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3441"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3443">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3445"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-231.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-235.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3968"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3958"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3950"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3997"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop5144" />
+      <stop
+         id="stop5146"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5148" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5172"
+       xlink:href="#linearGradient3944"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4202"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="translate(-4.0000003,0)" />
+    <linearGradient
+       y2="273"
+       x2="349"
+       y1="232"
+       x1="349"
+       gradientTransform="matrix(0.875,0,0,0.875,-262,-196.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6830"
+       xlink:href="#linearGradient4671"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="307"
+       y1="231"
+       x1="307"
+       gradientTransform="matrix(0.875,0,0,0.875,-263,-196.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6828"
+       xlink:href="#linearGradient4689"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         id="stop4673"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="273"
+       x2="349"
+       y1="232"
+       x1="349"
+       gradientTransform="matrix(0.875,0,0,0.875,-262,-196.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3189"
+       xlink:href="#linearGradient4671"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         id="stop4691"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="273"
+       x2="307"
+       y1="231"
+       x1="307"
+       gradientTransform="matrix(0.875,0,0,0.875,-263,-197.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3187"
+       xlink:href="#linearGradient4689"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937"
+       xlink:href="#linearGradient3952-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928"
+       xlink:href="#linearGradient3952-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920"
+       xlink:href="#linearGradient3914"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3988-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-3">
+      <stop
+         id="stop3990-5-0"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-3"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-8"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-1" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914"
+       inkscape:collect="always">
+      <stop
+         id="stop3916"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-1">
+      <stop
+         id="stop4673-9"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-5"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-6">
+      <stop
+         id="stop4691-1"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-5"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-5"
+       xlink:href="#linearGradient3960-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-8"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-8"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-7"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-2"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-1"
+       xlink:href="#linearGradient3914-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-3"
+       xlink:href="#linearGradient3988-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-9"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-2"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         id="stop3962-10"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-0" />
+      <stop
+         id="stop3964-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-8"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4689"
+       id="linearGradient4237"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-263,-196.5)"
+       x1="307"
+       y1="231"
+       x2="307"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4671"
+       id="linearGradient4239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-262,-196.5)"
+       x1="349"
+       y1="232"
+       x2="349"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4689"
+       id="linearGradient4248"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-309.36723,-196.5)"
+       x1="307"
+       y1="231"
+       x2="307"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4671"
+       id="linearGradient4392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-262,-196.5)"
+       x1="349"
+       y1="232"
+       x2="349"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4689"
+       id="linearGradient4403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-309.36723,-196.5)"
+       x1="307"
+       y1="231"
+       x2="307"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4671"
+       id="linearGradient4405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.875,-262,-196.5)"
+       x1="349"
+       y1="232"
+       x2="349"
+       y2="273" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3987"
+       d="m 42.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4205);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4214);fill-opacity:1;stroke:none"
+       d="m 42,42 0,3 0.5,0 C 43.331,45 44,44.331 44,43.5 44,42.669 43.331,42 42.5,42 L 42,42 z"
+       id="rect3940"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3989"
+       d="M 4.4866072,41.000001 C 3.6630268,41.000001 3,42.045313 3,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4202);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4211);fill-opacity:1;stroke:none"
+       d="m 5.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+       id="rect3942"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4208);fill-opacity:1;stroke:none"
+       d="m 5.1141432,41 37.7717148,0 0,5 -37.7717148,0 z"
+       id="rect3985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+       d="m 5.9998568,42 36.0002842,0 0,3 -36.0002842,0 z"
+       id="rect3938"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient3877);fill-opacity:1.0;stroke:none;display:inline"
+       d="M 6.4375 5 C 5.625551 5 5 5.6255532 5 6.4375 L 5 41.5625 C 5 42.374447 5.625551 43 6.4375 43 L 41.5625 43 C 42.374449 43 43 42.374447 43 41.5625 L 43 6.4375 C 43 5.6255532 42.374449 5 41.5625 5 L 6.4375 5 z "
+       id="rect4073" />
+    <rect
+       style="opacity:0.41;fill:none;stroke:#000000;stroke-opacity:1;display:inline"
+       id="rect4085"
+       width="39"
+       height="39"
+       x="-43.5"
+       y="-43.5"
+       transform="matrix(0,-1,-1,0,0,0)"
+       ry="1.95"
+       rx="1.9499974" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.14999999999999999;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       d="M 6.4375,5.00002 C 5.62555,5.00002 5,5.62557 5,6.43752 l 0,1 C 5,6.62557 5.62555,6.00002 6.4375,6.00002 l 35.125,0 c 0.81195,0 1.4375,0.62555 1.4375,1.4375 l 0,-1 c 0,-0.81195 -0.62555,-1.4375 -1.4375,-1.4375 l -35.125,0 z"
+       id="rect4089-4" />
+    <path
+       transform="matrix(0,1,-1,0,280,-784)"
+       style="opacity:0.10000000000000001;fill:none;stroke:url(#linearGradient4140);stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+       id="path4128"
+       clip-path="url(#clipPath4130)"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4105"
+       d="M 6.4375,43.000017 C 5.62555,43.000017 5,42.374417 5,41.562517 L 5,40.56252 c 0,0.811897 0.62555,1.437497 1.4375,1.437497 l 35.125,0 c 0.81195,0 1.4375,-0.6256 1.4375,-1.437497 l 0,0.999997 c 0,0.8119 -0.62555,1.4375 -1.4375,1.4375 l -35.125,0 z"
+       style="opacity:0.10000000000000001;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <g
+       id="g4394"
+       transform="translate(46.417226,0)">
+      <path
+         style="color:#000000;fill:url(#linearGradient4403);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         clip-path="none"
+         d="m -23.242226,10.499999 c -1.6008,0 -3.0225,0.46694 -4.0312,1.1875 -1.0089,0.72056 -1.5938,1.66347 -1.5938,2.6875 l 0,2.125 4.75,0 0,1 -5.25,0 -0.5,0 -2.125,0 c -1.0241,0 -1.9669,0.55371 -2.6875,1.5625 -0.7206,1.00879 -1.1875,2.46171 -1.1875,4.0625 l 0,1.75 c 0,1.60079 0.4669,3.02246 1.1875,4.03125 0.7206,1.00879 1.6634,1.59375 2.6875,1.59375 l 2.125,0 0,-3 c 0,-2.20735 1.7926,-4 4,-4 l 7,0 c 0,0 0.7756,-0.02838 1.5312,-0.40625 0.7559,-0.37787 1.4688,-1.01042 1.4688,-2.59375 l 0,-3.5 0,-2.625 c 0,-1.02403 -0.5849,-1.96693 -1.5938,-2.6875 -1.0086,-0.72057 -2.4304,-1.1875 -4.0312,-1.1875 l -1.75,0 z"
+         id="path9194"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.875,0,0,0.875,-309.36723,-200)"
+         d="m 327,244.5 c 0,0.82843 -0.67157,1.5 -1.5,1.5 -0.82843,0 -1.5,-0.67157 -1.5,-1.5 0,-0.82843 0.67157,-1.5 1.5,-1.5 0.82843,0 1.5,0.67157 1.5,1.5 z"
+         sodipodi:ry="1.5"
+         sodipodi:rx="1.5"
+         sodipodi:cy="244.5"
+         sodipodi:cx="325.5"
+         id="path9206"
+         style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+      <path
+         id="path7034"
+         d="m -23.242226,10.499999 c -1.6008,0 -3.0225,0.46694 -4.0312,1.1875 -1.0089,0.72056 -1.5938,1.66347 -1.5938,2.6875 l 0,2.125 4.75,0 0,1 -5.25,0 -0.5,0 -2.125,0 c -1.0241,0 -1.9669,0.55371 -2.6875,1.5625 -0.7206,1.00879 -1.1875,2.46171 -1.1875,4.0625 l 0,1.75 c 0,1.60079 0.4669,3.02246 1.1875,4.03125 0.7206,1.00879 1.6634,1.59375 2.6875,1.59375 l 2.125,0 0,-3 c 0,-2.20735 1.7926,-4 4,-4 l 7,0 c 0,0 0.7756,-0.02838 1.5312,-0.40625 0.7559,-0.37787 1.4688,-1.01042 1.4688,-2.59375 l 0,-3.5 0,-2.625 c 0,-1.02403 -0.5849,-1.96693 -1.5938,-2.6875 -1.0086,-0.72057 -2.4304,-1.1875 -4.0312,-1.1875 l -1.75,0 z"
+         clip-path="none"
+         style="opacity:0.61000001;color:#000000;fill:none;stroke:#043683;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <g
+         id="g3171"
+         transform="translate(-47.467226,-0.100001)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path9196"
+           d="m 32.5,17.5 0,3 c 0,2.20735 -1.7926,4 -4,4 l -7,0 c 0,0 -0.7756,-0.0029 -1.5312,0.375 C 19.2129,25.25287 18.5,25.91667 18.5,27.5 l 0,3.5 0,2.625 c 0,1.02403 0.5849,1.96693 1.5938,2.6875 1.0086,0.72057 2.4304,1.1875 4.0312,1.1875 l 1.75,0 c 1.6008,0 3.0225,-0.46694 4.0312,-1.1875 C 30.9151,35.59194 31.5,34.64903 31.5,33.625 l 0,-2.125 -4.75,0 0,-1 5.25,0 0.5,0 2.125,0 c 1.0241,0 1.9669,-0.58496 2.6875,-1.59375 C 38.0331,27.89746 38.5,26.47579 38.5,24.875 l 0,-1.75 c 0,-1.60079 -0.4669,-3.05371 -1.1875,-4.0625 C 36.5919,18.05371 35.6491,17.5 34.625,17.5 l -2.125,0 z"
+           style="color:#000000;fill:url(#linearGradient4405);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        <path
+           transform="matrix(0.875,0,0,0.875,-257.625,-179.875)"
+           d="m 327,244.5 c 0,0.82843 -0.67157,1.5 -1.5,1.5 -0.82843,0 -1.5,-0.67157 -1.5,-1.5 0,-0.82843 0.67157,-1.5 1.5,-1.5 0.82843,0 1.5,0.67157 1.5,1.5 z"
+           sodipodi:ry="1.5"
+           sodipodi:rx="1.5"
+           sodipodi:cy="244.5"
+           sodipodi:cx="325.5"
+           id="path9208"
+           style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           sodipodi:type="arc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:0.61000001;color:#000000;fill:none;stroke:#766e00;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           d="m 32.5,17.5 0,3 c 0,2.20735 -1.7926,4 -4,4 l -7,0 c 0,0 -0.7756,-0.0029 -1.5312,0.375 C 19.2129,25.25287 18.5,25.91667 18.5,27.5 l 0,3.5 0,2.625 c 0,1.02403 0.5849,1.96693 1.5938,2.6875 1.0086,0.72057 2.4304,1.1875 4.0312,1.1875 l 1.75,0 c 1.6008,0 3.0225,-0.46694 4.0312,-1.1875 C 30.9151,35.59194 31.5,34.64903 31.5,33.625 l 0,-2.125 -4.75,0 0,-1 5.25,0 0.5,0 2.125,0 c 1.0241,0 1.9669,-0.58496 2.6875,-1.59375 C 38.0331,27.89746 38.5,26.47579 38.5,24.875 l 0,-1.75 c 0,-1.60079 -0.4669,-3.05371 -1.1875,-4.0625 C 36.5919,18.05371 35.6491,17.5 34.625,17.5 l -2.125,0 z"
+           id="path7036" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-qtiplot.svg
+++ b/Faba/48x48/mimetypes/application-x-qtiplot.svg
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-qtiplot.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="17.933368"
+     inkscape:cy="22.527889"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       y2="-984"
+       x2="317"
+       y1="-939"
+       x1="317"
+       gradientTransform="matrix(1.0833333,0,0,0.88888892,-330.50001,878.16672)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3886"
+       xlink:href="#linearGradient20553"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient20553">
+      <stop
+         style="stop-color:#a348b1;stop-opacity:1;"
+         offset="0"
+         id="stop20555" />
+      <stop
+         style="stop-color:#bf7bca;stop-opacity:1;"
+         offset="1"
+         id="stop20557" />
+    </linearGradient>
+    <linearGradient
+       y2="-984"
+       x2="317"
+       y1="-939"
+       x1="317"
+       gradientTransform="matrix(1.0833333,0,0,0.88888892,-269.25001,808.66672)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4136"
+       xlink:href="#linearGradient20553"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-8"
+       id="linearGradient3996"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="4"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-8"
+       id="linearGradient3996-2"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="4"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         style="stop-color:#36d4af;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-49" />
+      <stop
+         style="stop-color:#1da5fd;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-36" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20,3)"
+       y2="4"
+       x2="24"
+       y1="44"
+       x1="24"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4789"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 7.5 3.5 L 7.5 4 L 7.5 43 L 7.5 43.5 L 8 43.5 L 40 43.5 L 40.5 43.5 L 40.5 43 L 40.5 4 L 40.5 3.5 L 40 3.5 L 8 3.5 L 7.5 3.5 z "
+       id="rect3882" />
+    <path
+       style="opacity:1;fill:url(#linearGradient3996);fill-opacity:1.0;stroke:none"
+       d="m 7.5,3.5 0,4 0,36 5.5,0 0,-35.5 27.5,0 0,-4.5 -28,0 z"
+       id="rect3955"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.1;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       id="path3968"
+       d="M 7.5 3.5 L 7.5 4 L 7.5 43 L 7.5 43.5 L 8 43.5 L 40 43.5 L 40.5 43.5 L 40.5 43 L 40.5 4 L 40.5 3.5 L 40 3.5 L 8 3.5 L 7.5 3.5 z "
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.41" />
+    <rect
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       id="rect4003"
+       width="5.5"
+       height="4.4990802"
+       x="7.5"
+       y="3.5009198" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <path
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 12 4 L 12 7 L 8 7 L 8 8 L 12 8 L 12 12 L 8 12 L 8 13 L 12 13 L 12 17 L 8 17 L 8 18 L 12 18 L 12 22 L 8 22 L 8 23 L 12 23 L 12 27 L 8 27 L 8 28 L 12 28 L 12 32 L 8 32 L 8 33 L 12 33 L 12 37 L 8 37 L 8 38 L 12 38 L 12 43 L 13 43 L 13 38 L 20 38 L 20 43 L 21 43 L 21 38 L 28 38 L 28 43 L 29 43 L 29 38 L 36 38 L 36 43 L 37 43 L 37 38 L 40 38 L 40 37 L 37 37 L 37 33 L 40 33 L 40 32 L 37 32 L 37 28 L 40 28 L 40 27 L 37 27 L 37 23 L 40 23 L 40 22 L 37 22 L 37 18 L 40 18 L 40 17 L 37 17 L 37 13 L 40 13 L 40 12 L 37 12 L 37 8 L 40 8 L 40 7 L 37 7 L 37 4 L 36 4 L 36 7 L 29 7 L 29 4 L 28 4 L 28 7 L 21 7 L 21 4 L 20 4 L 20 7 L 13 7 L 13 4 L 12 4 z M 13 8 L 20 8 L 20 12 L 13 12 L 13 8 z M 21 8 L 28 8 L 28 12 L 21 12 L 21 8 z M 29 8 L 36 8 L 36 12 L 29 12 L 29 8 z M 13 13 L 20 13 L 20 17 L 13 17 L 13 13 z M 21 13 L 28 13 L 28 17 L 21 17 L 21 13 z M 29 13 L 36 13 L 36 17 L 29 17 L 29 13 z M 13 18 L 20 18 L 20 22 L 13 22 L 13 18 z M 21 18 L 28 18 L 28 22 L 21 22 L 21 18 z M 29 18 L 36 18 L 36 22 L 29 22 L 29 18 z M 13 23 L 20 23 L 20 27 L 13 27 L 13 23 z M 21 23 L 28 23 L 28 27 L 21 27 L 21 23 z M 29 23 L 36 23 L 36 27 L 29 27 L 29 23 z M 13 28 L 20 28 L 20 32 L 13 32 L 13 28 z M 21 28 L 28 28 L 28 32 L 21 32 L 21 28 z M 29 28 L 36 28 L 36 32 L 29 32 L 29 28 z M 13 33 L 20 33 L 20 37 L 13 37 L 13 33 z M 21 33 L 28 33 L 28 37 L 21 37 L 21 33 z M 29 33 L 36 33 L 36 37 L 29 37 L 29 33 z "
+       id="rect3209" />
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-wine-extension-skb.svg
+++ b/Faba/48x48/mimetypes/application-x-wine-extension-skb.svg
@@ -1,0 +1,2347 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-wine-extension-skp.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="38.4919"
+     inkscape:cy="-36.360318"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3865">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3867" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3869" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880">
+      <stop
+         id="stop4882"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop4884"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:0.61" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient4688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         style="stop-color:#389fca;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#36acf4;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-61.529053,48.769197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4308"
+       xlink:href="#outerBackgroundGradient-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928"
+       id="linearGradient4868"
+       x1="24"
+       y1="48"
+       x2="24"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient3871"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16"
+       gradientTransform="matrix(2,0,0,2,-24,-24)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient7886"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient3432">
+      <stop
+         id="stop3434"
+         offset="0"
+         style="stop-color:#d7312c;stop-opacity:1;" />
+      <stop
+         id="stop3436"
+         offset="1"
+         style="stop-color:#f44f4a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-89"
+       xlink:href="#linearGradient3432"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-67"
+       id="linearGradient7855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.2105866e-7,-3.999999)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-67">
+      <stop
+         id="stop3864-8-6-6"
+         offset="0"
+         style="stop-color:#1d0100;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#4a2826;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-53"
+         offset="0"
+         style="stop-color:#805024;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-0"
+         offset="1"
+         style="stop-color:#e19043;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#0e52ab;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-6"
+         offset="1"
+         style="stop-color:#1ec49c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#3689e6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#90dbec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#65b11b;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#88da38;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4451"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4449"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3900"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3898"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3922"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3948"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3946"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4020"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4018"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3996"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3994"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3972"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4131">
+      <stop
+         id="stop4133"
+         offset="0"
+         style="stop-color:#8b2b28;stop-opacity:1;" />
+      <stop
+         id="stop4135"
+         offset="1"
+         style="stop-color:#cb2c31;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3970"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7220"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7218"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7216"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7214"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7212"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7210"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7208"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,214.29595,368.40292)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,326.29595,288.40292)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,430.29595,376.40292)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,382.29595,416.40292)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,342.29595,448.40292)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4180"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,54.295953,176.40292)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3039"
+       id="linearGradient4347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-212.52905,-72.230803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3039">
+      <stop
+         style="stop-color:#7767ad;stop-opacity:1"
+         offset="0"
+         id="stop3041" />
+      <stop
+         style="stop-color:#a594df;stop-opacity:1"
+         offset="1"
+         id="stop3043" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-5"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7742">
+      <stop
+         style="stop-color:#ffa622;stop-opacity:1;"
+         offset="0"
+         id="stop7744" />
+      <stop
+         style="stop-color:#ffbd52;stop-opacity:1;"
+         offset="1"
+         id="stop7746" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4684"
+       xlink:href="#linearGradient7742"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-0">
+      <stop
+         id="stop3864-8-6-9-8"
+         offset="0"
+         style="stop-color:#24ade7;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-9"
+         offset="1"
+         style="stop-color:#52cbfe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-8"
+       xlink:href="#outerBackgroundGradient-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928-3">
+      <stop
+         id="stop5930-7"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-1"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-3"
+       id="linearGradient7127-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-8" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-6"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-1"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-3">
+      <stop
+         id="stop4691-0"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-3"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-8"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-8"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-1"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-9"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-9"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-6"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880-3">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop4882-8" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:0.61"
+         offset="1"
+         id="stop4884-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient5124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-1"
+       id="linearGradient7888"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <clipPath
+       id="clipPath7848"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7850"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7844"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7846"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7840"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7842"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7836"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7838"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7832"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7834"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7828"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7830"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7824"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7826"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7820"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7822"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7816"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7818"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7812"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7814"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7808"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7810"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7804"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7806"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7800"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7802"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath5812"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path5815"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-1">
+      <stop
+         id="stop3864-8-6-52"
+         offset="0"
+         style="stop-color:#363a32;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-75"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-23"
+       xlink:href="#outerBackgroundGradient-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4105">
+      <stop
+         style="stop-color:#092b51;stop-opacity:1;"
+         offset="0"
+         id="stop4107" />
+      <stop
+         style="stop-color:#1772ca;stop-opacity:1;"
+         offset="1"
+         id="stop4109" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-7"
+       xlink:href="#linearGradient4105"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         id="stop3864-8-6-460"
+         offset="0"
+         style="stop-color:#bcbcbc;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1-8"
+         offset="1"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(-288,-316)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-0"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-30">
+      <stop
+         id="stop3864-8-6-5-9"
+         offset="0"
+         style="stop-color:#940005;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-70"
+         offset="1"
+         style="stop-color:#b11c21;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2-6"
+       xlink:href="#outerBackgroundGradient-30"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-4">
+      <stop
+         id="stop3864-8-6-46"
+         offset="0"
+         style="stop-color:#0068c6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#2888e0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8-8"
+       xlink:href="#outerBackgroundGradient-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(1.6692749e-6,-3.9999995)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4228"
+       xlink:href="#outerBackgroundGradient-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-9">
+      <stop
+         id="stop3864-8-6-4-1"
+         offset="0"
+         style="stop-color:#7395b9;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-7"
+         offset="1"
+         style="stop-color:#8fb3d9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       id="linearGradient4258"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4235"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.61907"
+       x2="283.80957"
+       y1="299.80954"
+       x1="283.80957"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3881"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="7"
+         y="53"
+         x="417"
+         height="30"
+         width="30"
+         id="rect3883"
+         style="color:#bebebe;fill:url(#linearGradient3885);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="28.571428"
+       x2="286.85715"
+       y1="302.85715"
+       x1="286.85715"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3875"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3871"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient3875);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3873"
+         width="22"
+         height="22"
+         x="417"
+         y="101"
+         ry="5" />
+    </clipPath>
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4350"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4346"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="18"
+         y="32"
+         x="292"
+         height="88"
+         width="88"
+         id="rect4348"
+         style="color:#bebebe;fill:url(#linearGradient4350);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="140"
+       x2="352"
+       y1="204"
+       x1="352"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4199"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4197"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140"
+       x2="352"
+       y1="204"
+       x1="352"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4191"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4187"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient4191);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4189"
+         width="60"
+         height="60"
+         x="290"
+         y="142"
+         ry="12.5" />
+    </clipPath>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-6"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40"
+       x2="144"
+       y1="280"
+       x1="144"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3866"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3862"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient3866);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3864"
+         width="220"
+         height="220"
+         x="34"
+         y="46"
+         ry="50" />
+    </clipPath>
+    <linearGradient
+       y2="40.00005"
+       x2="144"
+       y1="280.00003"
+       x1="144"
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,302.4,209.33333)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3859"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3855"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         ry="3"
+         y="212"
+         x="304"
+         height="16"
+         width="16"
+         id="rect3857"
+         style="color:#bebebe;fill:url(#linearGradient3859);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="40.00005"
+       x2="149.71432"
+       y1="291.42862"
+       x1="149.71432"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,430.13636,32.227267)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4093"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4089"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="6"
+         y="37"
+         x="433"
+         height="30"
+         width="30"
+         id="rect4091"
+         style="color:#bebebe;fill:url(#linearGradient4093);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="40.000046"
+       x2="149.71428"
+       y1="291.42862"
+       x1="149.71428"
+       gradientTransform="matrix(0.0875,0,0,0.0875,430.9,81.499996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4048"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4044"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient4048);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4046"
+         width="22"
+         height="22"
+         x="433"
+         y="85"
+         ry="4" />
+    </clipPath>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,302.79999,215.99997)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4895"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4891"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         style="color:#bebebe;fill:url(#linearGradient4895);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4893"
+         width="42"
+         height="42"
+         x="307"
+         y="223"
+         ry="9" />
+    </clipPath>
+    <linearGradient
+       y2="22.857315"
+       x2="281.14291"
+       y1="297.14304"
+       x1="281.14291"
+       gradientTransform="matrix(0.175,0,0,-0.175,286.79999,-215.99997)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4869"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.61907"
+       x2="283.80957"
+       y1="299.80954"
+       x1="283.80957"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4153"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28.571428"
+       x2="286.85715"
+       y1="302.85715"
+       x1="286.85715"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,414.4,137.33333)"
+       y2="40.00005"
+       x2="264"
+       y1="280.00003"
+       x1="264"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-63">
+      <stop
+         id="stop3864-8-6-2"
+         offset="0"
+         style="stop-color:#7469b3;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-753"
+         offset="1"
+         style="stop-color:#a6afe2;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       id="filter7554"
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend7556"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5608" />
+    </linearGradient>
+    <filter
+       id="filter7554-8"
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend7556-3"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5608-8" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606-8">
+      <stop
+         id="stop5608-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5374"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5376"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,9.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5388"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-40,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-64,-24)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5440"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,9.987521,-65.730803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-40,-60)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-64,-84)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-65.730803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-60)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-24,-84)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.2;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4870"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#2d6493;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.81" />
+    <path
+       style="opacity:0.2;fill:url(#radialGradient3871);fill-opacity:1;stroke:none"
+       d="m 10,4 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 z m 1,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z"
+       id="rect3813"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <g
+       id="g5126">
+      <path
+         style="opacity:0.2;fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         id="path4344"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path14126-7"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </g>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="81.302788"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-103.85196"
+         x="81.302788"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="188.78424"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-103.85196"
+         x="188.78424"
+         sodipodi:role="line"
+         id="tspan3937">sketchup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="482.29596"
+       y="16.40292"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="482.29596"
+       y="-23.59708"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="482.29596"
+       y="-71.597076"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-22.59708"
+       x="483.29596"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="96.402924"
+       x="354.29596"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="82.295952"
+       y="-95.597076"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="354.29596"
+       y="16.40292"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="354.29596"
+       y="-95.597076"
+       inkscape:label="96x96" />
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-802.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context-6"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-144.75488"
+         x="-802.49316"
+         sodipodi:role="line"
+         id="tspan3933-5">apps</tspan></text>
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-695.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name-4"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-144.75488"
+         x="-695.01172"
+         sodipodi:role="line"
+         id="tspan3937-1">deja-dup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16-9"
+       width="16"
+       height="16"
+       x="-401.5"
+       y="-24.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24-5"
+       width="24"
+       height="24"
+       x="-401.5"
+       y="-64.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32-5"
+       width="32"
+       height="32"
+       x="-401.5"
+       y="-112.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-63.5"
+       x="-400.5"
+       height="22"
+       width="22"
+       id="rect22x22-9"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="55.5"
+       x="-529.5"
+       height="48"
+       width="48"
+       id="rect48x48-9"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256-6"
+       width="256"
+       height="256"
+       x="-801.5"
+       y="-136.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64-0"
+       width="64"
+       height="64"
+       x="-529.5"
+       y="-24.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96-6"
+       width="96"
+       height="96"
+       x="-529.5"
+       y="-136.5"
+       inkscape:label="96x96" />
+    <g
+       id="g4857"
+       transform="matrix(0.58168969,0,0,0.58168969,6.8471048,22.423906)">
+      <g
+         transform="translate(20,0)"
+         id="g4085" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.2;color:#bebebe;fill:none;stroke:#ffffff;stroke-width:0.78246051;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path3106"
+         sodipodi:cx="290"
+         sodipodi:cy="295.5"
+         sodipodi:rx="3"
+         sodipodi:ry="2.5"
+         d="m 293,295.5 c 0,1.38071 -1.34315,2.5 -3,2.5 -1.65685,0 -3,-1.11929 -3,-2.5 0,-1.38071 1.34315,-2.5 3,-2.5 1.65685,0 3,1.11929 3,2.5 z"
+         transform="matrix(2.5070663,0,0,3.0084762,-682.089,-865.66565)" />
+      <g
+         transform="translate(20,0)"
+         id="g4080">
+        <path
+           sodipodi:type="arc"
+           style="color:#bebebe;fill:none;stroke:#ffffff;stroke-width:0.78246129;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           id="path3108"
+           sodipodi:cx="290"
+           sodipodi:cy="295.5"
+           sodipodi:rx="3"
+           sodipodi:ry="2.5"
+           d="m 287.00003,295.51059 c -0.007,-1.3807 1.33042,-2.50472 2.98726,-2.51057 1.65684,-0.006 3.00566,1.10869 3.01268,2.48939 0.007,1.37732 -1.32413,2.49992 -2.97689,2.51052"
+           transform="matrix(2.5070663,0,0,3.0084762,-702.089,-865.66565)"
+           sodipodi:start="3.1373554"
+           sodipodi:end="7.8462895"
+           sodipodi:open="true" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+           d="m 287,294 -3.05714,-5.02858 6.05714,0 z"
+           id="path3110"
+           inkscape:connector-curvature="0"
+           transform="matrix(1.074457,0,0,1.074457,-290.93013,-288.25338)"
+           sodipodi:nodetypes="cccc"
+           clip-path="url(#clipPath5812)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/application-x-wine-extension-skp.svg
+++ b/Faba/48x48/mimetypes/application-x-wine-extension-skp.svg
@@ -1,0 +1,1264 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-wine-extension-skb.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="23.668756"
+     inkscape:cy="-11.797722"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3865">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3867" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3869" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880">
+      <stop
+         id="stop4882"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop4884"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:0.61" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient4688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         style="stop-color:#389fca;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#36acf4;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-61.529053,48.769197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4308"
+       xlink:href="#outerBackgroundGradient-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928"
+       id="linearGradient4868"
+       x1="24"
+       y1="48"
+       x2="24"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient3871"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16"
+       gradientTransform="matrix(2,0,0,2,-24,-24)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient7886"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient3432">
+      <stop
+         id="stop3434"
+         offset="0"
+         style="stop-color:#d7312c;stop-opacity:1;" />
+      <stop
+         id="stop3436"
+         offset="1"
+         style="stop-color:#f44f4a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-89"
+       xlink:href="#linearGradient3432"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-67"
+       id="linearGradient7855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.2105866e-7,-3.999999)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-67">
+      <stop
+         id="stop3864-8-6-6"
+         offset="0"
+         style="stop-color:#1d0100;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#4a2826;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-53"
+         offset="0"
+         style="stop-color:#805024;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-0"
+         offset="1"
+         style="stop-color:#e19043;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#0e52ab;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-6"
+         offset="1"
+         style="stop-color:#1ec49c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#3689e6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#90dbec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#65b11b;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#88da38;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4451"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4449"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3900"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3898"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3922"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3948"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3946"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4020"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4018"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3996"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3994"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3972"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4131">
+      <stop
+         id="stop4133"
+         offset="0"
+         style="stop-color:#8b2b28;stop-opacity:1;" />
+      <stop
+         id="stop4135"
+         offset="1"
+         style="stop-color:#cb2c31;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3970"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7220"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7218"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7216"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7214"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7212"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7210"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7208"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,214.29595,368.40292)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,326.29595,288.40292)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,430.29595,376.40292)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,382.29595,416.40292)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,342.29595,448.40292)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4180"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,54.295953,176.40292)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3039"
+       id="linearGradient4347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-212.52905,-72.230803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3039">
+      <stop
+         style="stop-color:#7767ad;stop-opacity:1"
+         offset="0"
+         id="stop3041" />
+      <stop
+         style="stop-color:#a594df;stop-opacity:1"
+         offset="1"
+         id="stop3043" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-5"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7742">
+      <stop
+         style="stop-color:#ffa622;stop-opacity:1;"
+         offset="0"
+         id="stop7744" />
+      <stop
+         style="stop-color:#ffbd52;stop-opacity:1;"
+         offset="1"
+         id="stop7746" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4684"
+       xlink:href="#linearGradient7742"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-0">
+      <stop
+         id="stop3864-8-6-9-8"
+         offset="0"
+         style="stop-color:#24ade7;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-9"
+         offset="1"
+         style="stop-color:#52cbfe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-8"
+       xlink:href="#outerBackgroundGradient-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928-3">
+      <stop
+         id="stop5930-7"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-1"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-3"
+       id="linearGradient7127-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-8" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-6"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-1"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-3">
+      <stop
+         id="stop4691-0"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-3"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-8"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-8"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-1"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-9"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-9"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-6"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880-3">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop4882-8" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:0.61"
+         offset="1"
+         id="stop4884-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient5124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.2;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4870"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#2d6493;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.81" />
+    <path
+       style="opacity:0.20000000000000001;fill:url(#radialGradient3871);fill-opacity:1;stroke:none"
+       d="m 10,4 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 z m 1,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z"
+       id="rect3813"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="81.302788"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-103.85196"
+         x="81.302788"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="188.78424"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-103.85196"
+         x="188.78424"
+         sodipodi:role="line"
+         id="tspan3937">sketchup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="482.29596"
+       y="16.40292"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="482.29596"
+       y="-23.59708"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="482.29596"
+       y="-71.597076"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-22.59708"
+       x="483.29596"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="96.402924"
+       x="354.29596"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="82.295952"
+       y="-95.597076"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="354.29596"
+       y="16.40292"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="354.29596"
+       y="-95.597076"
+       inkscape:label="96x96" />
+    <g
+       id="g5126">
+      <path
+         style="opacity:0.2;fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         id="path4344"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path14126-7"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/template_source.svg
+++ b/Faba/48x48/mimetypes/template_source.svg
@@ -1,0 +1,1 @@
+text-x-generic-template.svg

--- a/Faba/48x48/mimetypes/text-c.svg
+++ b/Faba/48x48/mimetypes/text-c.svg
@@ -1,0 +1,1 @@
+text-x-c.svg

--- a/Faba/48x48/mimetypes/text-css.svg
+++ b/Faba/48x48/mimetypes/text-css.svg
@@ -1,0 +1,1 @@
+text-x-css.svg

--- a/Faba/48x48/mimetypes/text-x-csrc.svg
+++ b/Faba/48x48/mimetypes/text-x-csrc.svg
@@ -1,0 +1,1 @@
+text-x-c.svg

--- a/Faba/48x48/mimetypes/text-x-markdown.svg
+++ b/Faba/48x48/mimetypes/text-x-markdown.svg
@@ -1,0 +1,2263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-markdown.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       id="linearGradient5928-0">
+      <stop
+         id="stop5930-2"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-5"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-0"
+       id="linearGradient7127-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-2">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-1" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-6">
+      <stop
+         id="stop4673-4"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-07"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-8">
+      <stop
+         id="stop4691-34"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-8"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-5"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-1"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-2"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-2"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-7"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-01"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-5"
+       xlink:href="#linearGradient3914-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-5"
+       xlink:href="#linearGradient3988-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-7"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-98"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-94"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-80">
+      <stop
+         id="stop3962-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-6" />
+      <stop
+         id="stop3964-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-93"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4274"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-360,-81.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-310.79998,-86.500033)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-2"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-3"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-6"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-4"
+       xlink:href="#linearGradient3988-5-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-82">
+      <stop
+         id="stop3990-5-37"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-72"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-57"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-16"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-71" />
+      <stop
+         id="stop3964-79"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4411"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4413"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4415"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4420"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-351.74399,-38.548621)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-302.54397,-43.548654)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       gradientTransform="translate(-4.0000003,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4214"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4211"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4208"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4205"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4202"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-9"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-45"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-10"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-90"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-4"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-90">
+      <stop
+         id="stop3962-76"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-3"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-75"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-8"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-1"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3877"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-5"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4736"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4738"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4744"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background"
+     style="display:inline">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.4;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       d="M 34.269233,17 H 13.730767 C 12.776413,17 12,17.776414 12,18.730768 V 30.269232 C 12,31.223634 12.776413,32 13.730767,32 H 34.269233 C 35.223634,32 36,31.223634 36,30.269232 V 18.730768 C 36,17.776414 35.223634,17 34.269233,17 z M 25.5,28.997068 l -3,0.0027 v -4.5 L 20.25,27.384416 18,24.4998 v 4.5 h -3 v -9 h 3 l 2.25,3 2.25,-3 3,-0.0027 v 9 z m 4.478693,0.75 L 26.25,24.5 H 28.5 V 20 h 3 v 4.5 h 2.25 l -3.771307,5.247068 z"
+       id="path3519"
+       style="fill:#ffffff;opacity:0.4" />
+    <path
+       id="path3510"
+       d="M 34.269233,16 H 13.730767 C 12.776413,16 12,16.776414 12,17.730768 V 29.269232 C 12,30.223634 12.776413,31 13.730767,31 H 34.269233 C 35.223634,31 36,30.223634 36,29.269232 V 17.730768 C 36,16.776414 35.223634,16 34.269233,16 z M 25.5,27.997068 l -3,0.0027 v -4.5 L 20.25,26.384416 18,23.4998 v 4.5 h -3 v -9 h 3 l 2.25,3 2.25,-3 3,-0.0027 v 9 z m 4.478693,0.75 L 26.25,23.5 H 28.5 V 19 h 3 v 4.5 h 2.25 l -3.771307,5.247068 z"
+       inkscape:connector-curvature="0"
+       style="fill:#cccccc;fill-opacity:1" />
+    <path
+       d="M 13.71875,16 C 12.764396,16 12,16.764396 12,17.71875 l 0,1 C 12,17.764396 12.764396,17 13.71875,17 l 20.5625,0 C 35.235651,17 36,17.764396 36,18.71875 l 0,-1 C 36,16.764396 35.235651,16 34.28125,16 l -20.5625,0 z M 18,23.5 l 0,1 2.25,2.875 2.25,-2.875 0,-1 -2.25,2.875 L 18,23.5 z m 8.25,1 3.71875,5.25 3.78125,-5.25 -0.71875,0 -3.0625,4.25 -3,-4.25 -0.71875,0 z M 15,28 l 0,1 3,0 0,-1 -3,0 z m 7.5,0 0,1 3,0 0,-1 -3,0 z"
+       id="path3521"
+       inkscape:connector-curvature="0"
+       style="opacity:0.1;fill:#000000" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol"
+     style="display:inline">
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/text-x-ms-regedit.svg
+++ b/Faba/48x48/mimetypes/text-x-ms-regedit.svg
@@ -1,0 +1,2267 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-ms-regedit.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       id="linearGradient5928-0">
+      <stop
+         id="stop5930-2"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-5"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-0"
+       id="linearGradient7127-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-2">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-1" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-6">
+      <stop
+         id="stop4673-4"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-07"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-8">
+      <stop
+         id="stop4691-34"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-8"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-5"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-1"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-2"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-2"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-7"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-01"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-5"
+       xlink:href="#linearGradient3914-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-5"
+       xlink:href="#linearGradient3988-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-7"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-98"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-94"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-80">
+      <stop
+         id="stop3962-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-6" />
+      <stop
+         id="stop3964-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-93"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4274"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-360,-81.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-310.79998,-86.500033)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-2"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-3"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-6"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-4"
+       xlink:href="#linearGradient3988-5-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-82">
+      <stop
+         id="stop3990-5-37"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-72"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-57"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-16"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-71" />
+      <stop
+         id="stop3964-79"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4411"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4413"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4415"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4420"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-351.74399,-38.548621)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-302.54397,-43.548654)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       gradientTransform="translate(-4.0000003,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4214"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4211"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4208"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4205"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4202"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-9"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-45"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-10"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-90"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-4"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-90">
+      <stop
+         id="stop3962-76"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-3"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-75"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-8"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-1"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3877"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-5"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4736"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4738"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4744"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background"
+     style="display:inline">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.4;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol"
+     style="display:inline">
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+    <g
+       id="g5011"
+       transform="translate(-80,-2)">
+      <path
+         id="rect4926"
+         d="M 112,14.75 107.75,19 112,23.25 116.25,19 112,14.75 z M 94,17 l 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -7,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -14,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z"
+         style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4680"
+         d="M 112,13.75 107.75,18 112,22.25 116.25,18 112,13.75 z M 94,16 l 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -7,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -14,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z"
+         style="color:#000000;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5004"
+         d="m 112,13.75 -4.25,4.25 0.5,0.5 3.75,-3.75 3.75,3.75 0.5,-0.5 L 112,13.75 z M 94,16 l 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m -7,7 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -1.75,0 L 112,23.25 111.75,23 108,23 z m -14,7 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z"
+         style="opacity:0.1;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/Faba/48x48/mimetypes/text-x-tex.svg
+++ b/Faba/48x48/mimetypes/text-x-tex.svg
@@ -1,0 +1,1805 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-tex.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="66.75822"
+     inkscape:cy="18.931965"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-1"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-8"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-78" />
+      <stop
+         id="stop3964-78"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-7"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-1"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-0"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-4"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-3"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-3">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-89">
+      <stop
+         id="stop5930-1"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-7"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-89"
+       id="linearGradient7127-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-6">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-5" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-1">
+      <stop
+         id="stop4673-0"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-4"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-4">
+      <stop
+         id="stop4691-9"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-4"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5-53">
+      <stop
+         id="stop3990-5-9"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-97"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-25"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-72" />
+      <stop
+         id="stop3964-25"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4498"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4500"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4502"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4504"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4506"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4538"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4542"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4544"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4546"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4548"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4550"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,129.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(80,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4626"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,169.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(120,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.40000000000000002;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.40000000000000002;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <g
+       id="g4662"
+       transform="translate(-40,0)">
+      <path
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman"
+         d="m 67.0625,17.43725 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 2.78125,4.21875 -2.5,3.65625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.559752,0 1.392876,0.01711 1.9375,0.0625 l 0,-0.46875 c -0.695908,-0.01513 -0.96875,-0.446438 -0.96875,-0.71875 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 l 2.15625,-3.1875 2.375,3.625 c 0.03026,0.06051 0.09375,0.110865 0.09375,0.15625 0,0.181541 -0.349477,0.453621 -1,0.46875 l 0,0.46875 c 0.529496,-0.04539 1.643869,-0.0625 2.21875,-0.0625 L 77.5,27.781 l 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 l -3.1875,-4.8125 2.0625,-3.03125 c 0.332826,-0.48411 0.87232,-0.984871 2.21875,-1 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 l 0,0.46875 c 0.605138,0.01513 0.9375,0.339546 0.9375,0.6875 0,0.151284 -0.0191,0.208587 -0.125,0.375 l -1.75,2.53125 -1.9375,-2.90625 c -0.03026,-0.04539 -0.09375,-0.158237 -0.09375,-0.21875 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 c -0.529495,0.04539 -1.64387,0.0625 -2.21875,0.0625 L 67.0625,17.43725 z M 50.78125,17.531 50.5,20.93725 l 0.375,0 c 0.211798,-2.435678 0.434356,-2.9375 2.71875,-2.9375 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.317697,0.06051 0.34375,0.214546 0.34375,0.5625 l 0,7.96875 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.620266,-0.04539 2.179092,-0.0625 2.875,-0.0625 0.695908,0 2.254735,0.01711 2.875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 l 0,-7.96875 c 0,-0.302569 -0.02231,-0.501986 0.25,-0.5625 0.166413,-0.03026 0.58756,-0.03125 0.875,-0.03125 2.284393,0 2.506952,0.501822 2.71875,2.9375 l 0.375,0 -0.28125,-3.40625 -9.25,0 z m 8.1875,3.96875 0,0.46875 0.375,0 c 1.164889,0 1.1875,0.142876 1.1875,0.6875 l 0,7.9375 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 8.71875,0 0.65625,-3.90625 -0.40625,0 c -0.378211,2.329779 -0.71041,3.4375 -3.3125,3.4375 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,-4.03125 1.34375,0 c 1.467458,0 1.65625,0.495333 1.65625,1.78125 l 0.375,0 0,-4.03125 -0.375,0 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,-3.625 c 0,-0.499238 0.03897,-0.59375 0.75,-0.59375 l 1.9375,0 c 2.31465,0 2.726695,0.803397 2.96875,2.90625 l 0.375,0 -0.4375,-3.375 -8.5,0 z"
+         id="path4508"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4447"
+         d="m 67.0625,16.4375 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 2.78125,4.21875 -2.5,3.65625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.559752,0 1.392876,0.01711 1.9375,0.0625 l 0,-0.46875 c -0.695908,-0.01513 -0.96875,-0.446438 -0.96875,-0.71875 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 l 2.15625,-3.1875 2.375,3.625 c 0.03026,0.06051 0.09375,0.110865 0.09375,0.15625 0,0.181541 -0.349477,0.453621 -1,0.46875 l 0,0.46875 c 0.529496,-0.04539 1.643869,-0.0625 2.21875,-0.0625 l 1.96875,0.0625 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 l -3.1875,-4.8125 2.0625,-3.03125 c 0.332826,-0.48411 0.87232,-0.984871 2.21875,-1 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 l 0,0.46875 c 0.605138,0.01513 0.9375,0.339546 0.9375,0.6875 0,0.151284 -0.0191,0.208587 -0.125,0.375 L 72.3125,20.5 70.375,17.59375 c -0.03026,-0.04539 -0.09375,-0.158237 -0.09375,-0.21875 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 C 70.720505,16.48289 69.60613,16.5 69.03125,16.5 L 67.0625,16.4375 z M 50.78125,16.53125 50.5,19.9375 l 0.375,0 C 51.086798,17.501822 51.309356,17 53.59375,17 c 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.317697,0.06051 0.34375,0.214546 0.34375,0.5625 l 0,7.96875 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.620266,-0.04539 2.179092,-0.0625 2.875,-0.0625 0.695908,0 2.254735,0.01711 2.875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 l 0,-7.96875 c 0,-0.302569 -0.02231,-0.501986 0.25,-0.5625 C 56.510163,17.00099 56.93131,17 57.21875,17 c 2.284393,0 2.506952,0.501822 2.71875,2.9375 l 0.375,0 -0.28125,-3.40625 -9.25,0 z m 8.1875,3.96875 0,0.46875 0.375,0 c 1.164889,0 1.1875,0.142876 1.1875,0.6875 l 0,7.9375 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 8.71875,0 0.65625,-3.90625 -0.40625,0 c -0.378211,2.329779 -0.71041,3.4375 -3.3125,3.4375 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,-4.03125 1.34375,0 c 1.467458,0 1.65625,0.495333 1.65625,1.78125 l 0.375,0 0,-4.03125 -0.375,0 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,-3.625 c 0,-0.499238 0.03897,-0.59375 0.75,-0.59375 l 1.9375,0 c 2.31465,0 2.726695,0.803397 2.96875,2.90625 l 0.375,0 -0.4375,-3.375 -8.5,0 z"
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#cccccc;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman" />
+      <path
+         id="path4558"
+         d="m 67.0625,16.4375 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 0.03125,0.0625 0.21875,0 c 0.331938,0 0.806029,-0.01769 1.28125,-0.03125 -0.01489,-0.03447 -0.03125,-0.06871 -0.03125,-0.09375 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 C 70.720505,16.48289 69.60613,16.5 69.03125,16.5 L 67.0625,16.4375 z m 6.1875,0 0,0.46875 c 0.529496,0.01324 0.83436,0.267096 0.90625,0.5625 0.311505,0.01 0.616294,0.0302 0.90625,0.03125 0.357672,-0.31258 0.873481,-0.583199 1.8125,-0.59375 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 z M 50.78125,16.53125 50.5,19.9375 l 0.09375,0 0.1875,-2.40625 0.71875,0 C 51.871428,17.128058 52.481528,17 53.59375,17 c 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.295004,0.05619 0.339036,0.202148 0.34375,0.5 l 1.34375,0 c -0.0014,-0.261644 2.26e-4,-0.444494 0.25,-0.5 C 56.510163,17.00099 56.93131,17 57.21875,17 c 1.112222,0 1.722322,0.128058 2.09375,0.53125 l 0.71875,0 0.1875,2.40625 0.09375,0 -0.28125,-3.40625 -9.25,0 z m 19.875,1.5 c -0.238699,0.09922 -0.375,0.233312 -0.375,0.34375 0,0.06051 0.06349,0.17336 0.09375,0.21875 L 72.3125,21.5 72.65625,21.03125 72.59375,20.9375 74.1875,18.59375 c 0,-0.173977 -0.09127,-0.342261 -0.25,-0.46875 L 72.3125,20.5 70.65625,18.03125 z M 58.96875,20.5 l 0,0.46875 0.375,0 c 1.0336,0 1.170358,0.125442 1.1875,0.53125 l 1.34375,0 c 0.0051,-0.437158 0.07417,-0.53125 0.75,-0.53125 l 1.9375,0 c 1.026983,0 1.664524,0.17161 2.09375,0.53125 l 0.8125,0 0.3125,2.375 0.125,0 -0.4375,-3.375 -7.1875,0 0.03125,0.4375 -0.375,0 C 59.9232,20.773047 59.89003,20.647262 59.875,20.5 l -0.90625,0 z m 13.96875,0.9375 -0.34375,0.5 3.15625,4.78125 1.75,0.0625 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 L 72.9375,21.4375 z m -1.71875,0.71875 -2.15625,3.15625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.03607,0 0.0868,-1.45e-4 0.125,0 0.166529,-0.15495 0.30127,-0.300922 0.375,-0.40625 l 0.46875,-0.6875 c -6e-4,-0.0093 0,-0.02226 0,-0.03125 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 L 71.5,22.5625 71.21875,22.15625 z m -6.34375,1.25 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,0.46875 1.34375,0 c 0.606405,0 0.972136,0.09125 1.21875,0.28125 0.364197,-0.264508 0.4375,-0.756363 0.4375,-1.53125 l 0.375,0 0,-1 -0.375,0 z M 54.75,25.5625 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.47875,-0.03503 1.450076,-0.05603 2.21875,-0.0625 0.0024,-0.05095 0,-0.09828 0,-0.15625 l 0,-1 z m 1.34375,0 0,1 c 0,0.05797 -0.0017,0.105298 0,0.15625 0.765165,0.0067 1.715489,0.02796 2.1875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 z M 69.8125,26.09375 69.6875,26.25 c -0.10589,0.166413 -0.15625,0.207594 -0.15625,0.34375 0,0.04753 0.01383,0.102095 0.03125,0.15625 0.334979,0.01 0.673963,0.0093 0.9375,0.03125 l 0,-0.46875 c -0.313159,-0.0068 -0.531994,-0.0958 -0.6875,-0.21875 z m 4.09375,0.09375 c -0.156723,0.05962 -0.349804,0.119327 -0.59375,0.125 l 0,0.46875 C 73.536263,26.76207 73.90219,26.75992 74.25,26.75 74.23412,26.72954 74.23032,26.71064 74.21875,26.6875 l -0.3125,-0.5 z M 67.9375,26.875 c -0.01821,0.112168 -0.04425,0.205984 -0.0625,0.3125 0.175657,-0.04959 0.308299,-0.119075 0.4375,-0.1875 l 0.03125,-0.125 -0.40625,0 z m 0.25,0.84375 -0.40625,0.03125 c -0.352936,1.7301 -0.906429,2.5625 -3.15625,2.5625 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,1 c 0,0.03707 -6.89e-4,0.06069 0,0.09375 l 4.90625,0 c 0.70807,-0.540212 0.92742,-1.496659 1.15625,-2.90625 l 0.25,0 0,-0.15625 z m -7.65625,1.875 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 1.53125,0 c 0.0037,-0.06132 0.03125,-0.112726 0.03125,-0.1875 l 0,-1 z"
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman"
+         inkscape:connector-curvature="0" />
+    </g>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-epub+zip.svg
+++ b/src/vector/48x48/mimetypes/application-epub+zip.svg
@@ -1,0 +1,1615 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-epub+zip.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="3.6522716"
+     inkscape:cy="50.337385"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient4439">
+      <stop
+         offset="0"
+         style="stop-color:#85b916;stop-opacity:1;"
+         id="stop4441" />
+      <stop
+         offset="1"
+         style="stop-color:#4c680d;stop-opacity:1;"
+         id="stop4443" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4433">
+      <stop
+         offset="0"
+         style="stop-color:#beeb5c;stop-opacity:1;"
+         id="stop4435" />
+      <stop
+         offset="1"
+         style="stop-color:#88b32d;stop-opacity:1;"
+         id="stop4437" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#linearGradient4433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#linearGradient4439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#linearGradient4439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4499"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4496"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4493"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4490"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4487"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4484"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4481"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4478"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4476"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4474"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4348"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4346"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4344"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4342"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4340"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4338"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4336"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4254"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4256"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4260"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4262"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4264"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4266"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient3870"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         style="stop-color:#c01914;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6" />
+      <stop
+         style="stop-color:#d4231e;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-8" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         style="stop-color:#e5523c;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-2" />
+      <stop
+         style="stop-color:#ed8879;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-81" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4636-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-6" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-2"
+       xlink:href="#linearGradient4636-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient4087-4"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-1"
+       id="radialGradient4085-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-8"
+       id="linearGradient3927-9"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-2" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-1"
+       id="radialGradient3015-2-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-3" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-6"
+       id="radialGradient3013-6-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient3092-1-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3090-9-9"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-3" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9"
+       id="linearGradient3087-4-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-6">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3085-9-4"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6"
+       id="linearGradient3077-8-3"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-6" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4"
+       id="radialGradient3075-2-8"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-7" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-1" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-5"
+       id="linearGradient3072-7-5"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3092-7"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3090-8"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3087-8"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3085-8"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3082-2"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3080-1"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3077-6"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3075-3"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-7"
+       id="linearGradient3072-9"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient4043-6"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-6" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-1" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3015-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3013-7"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-8" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-94">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-7" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-69">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-6" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-9">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-89" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-2" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-5" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-5" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-3" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-9" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient3643"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3645"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3647"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3649"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       cx="24.501682"
+       cy="6.6475959"
+       fx="24.501682"
+       fy="6.6475959"
+       r="17.49832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-6"
+       id="linearGradient3661"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128837"
+     y="4.5095215"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1.0;stroke:url(#linearGradient3082);stroke-width:1.01904118000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4445"
+     transform="translate(0,0.39699975)">
+    <path
+       style="opacity:0.2;fill:#000000"
+       inkscape:connector-curvature="0"
+       d="m 25.939169,31.259301 -5.65624,-5.656702 5.65624,-5.6559 1.88557,1.885224 -3.77114,3.770676 1.88545,1.885567 5.65625,-5.655899 -4.92725,-4.927249 c -0.40235,-0.402691 -1.05496,-0.402691 -1.45765,0 l -7.96927,7.969274 c -0.40235,0.402347 -0.40235,1.054955 0,1.457645 l 7.96939,7.969045 c 0.40269,0.402691 1.0553,0.402691 1.45764,0 l 7.96939,-7.969045 c 0.40235,-0.40269 0.40235,-1.055298 0,-1.457645 l -1.15691,-1.156573 -7.54147,7.541582 z"
+       id="path3663" />
+    <path
+       id="path3284"
+       d="m 25.939169,30.25957 -5.65624,-5.656702 5.65624,-5.6559 1.88557,1.885224 -3.77114,3.770676 1.88545,1.885567 5.65625,-5.655899 -4.92725,-4.927249 c -0.40235,-0.402691 -1.05496,-0.402691 -1.45765,0 l -7.96927,7.969274 c -0.40235,0.402347 -0.40235,1.054955 0,1.457645 l 7.96939,7.969045 c 0.40269,0.402691 1.0553,0.402691 1.45764,0 l 7.96939,-7.969045 c 0.40235,-0.40269 0.40235,-1.055298 0,-1.457645 l -1.15691,-1.156573 -7.54147,7.541582 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;fill-opacity:1" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-mathematica.svg
+++ b/src/vector/48x48/mimetypes/application-mathematica.svg
@@ -1,0 +1,1057 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-mathematica.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="65.997598"
+     inkscape:cy="0.59744863"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#outerBackgroundGradient-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#outerBackgroundGradient"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#outerBackgroundGradient"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         id="stop4351-7"
+         offset="0"
+         style="stop-color:#f5f5f5;stop-opacity:1;" />
+      <stop
+         id="stop4353-81"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         id="stop3864-8-6-2"
+         offset="0"
+         style="stop-color:#e5523c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-6"
+         offset="1"
+         style="stop-color:#ed8879;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         id="stop4351-5"
+         offset="0"
+         style="stop-color:#f5f5f5;stop-opacity:1;" />
+      <stop
+         id="stop4353-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#c01914;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d4231e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3870"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       id="linearGradient4266"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       id="linearGradient4264"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       id="linearGradient4262"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       id="linearGradient4260"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       id="linearGradient4256"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       id="linearGradient4254"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4336"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4344"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4474"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4481"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4487"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4493"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128822"
+     y="-45.490479"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1;stroke:url(#linearGradient3082);stroke-width:1.01904118;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     transform="scale(1,-1)" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <text
+     y="-157.75488"
+     xml:space="preserve"
+     x="116.50684"
+     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+     inkscape:label="context"
+     id="context"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       y="-157.75488"
+       x="116.50684"
+       sodipodi:role="line"
+       id="tspan3933">apps</tspan></text>
+  <text
+     y="-157.75488"
+     xml:space="preserve"
+     x="223.98828"
+     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+     sodipodi:linespacing="125%"
+     inkscape:label="icon-name"
+     id="icon-name"><tspan
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       y="-157.75488"
+       x="223.98828"
+       sodipodi:role="line"
+       id="tspan3937">mathematica</tspan></text>
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect16x16"
+     width="16"
+     height="16"
+     x="517.5"
+     y="-37.5"
+     inkscape:label="16x16" />
+  <rect
+     style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect24x24"
+     width="24"
+     height="24"
+     x="517.5"
+     y="-77.5"
+     inkscape:label="24x24" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect32x32"
+     width="32"
+     height="32"
+     x="517.5"
+     y="-125.5"
+     inkscape:label="32x32" />
+  <rect
+     inkscape:label="22x22"
+     y="-76.5"
+     x="518.5"
+     height="22"
+     width="22"
+     id="rect22x22"
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+  <rect
+     inkscape:label="48x48"
+     y="42.5"
+     x="389.5"
+     height="48"
+     width="48"
+     id="rect48x48"
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect256x256"
+     width="256"
+     height="256"
+     x="117.5"
+     y="-149.5"
+     inkscape:label="256x256" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect64x64"
+     width="64"
+     height="64"
+     x="389.5"
+     y="-37.5"
+     inkscape:label="64x64" />
+  <rect
+     style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+     id="rect96x96"
+     width="96"
+     height="96"
+     x="389.5"
+     y="-149.5"
+     inkscape:label="96x96" />
+  <g
+     id="g4520"
+     transform="matrix(0.62068966,0,0,0.62068966,4.0600282,9.327586)">
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
+       d="m 35.62037,11.75 -3.02222,4.85926 -5.4074,-2.28148 0.6074,6.02963 -5.46667,0.99259 4,4.11852 -4.68148,4.42963 6.20741,0.99259 -0.97778,6.28148 5.54074,-2.9037 2.88889,5.48148 2.88889,-5.40741 5.17037,2.75556 L 43.25,31.20185 48.85,30.52036 44.90926,25.83889 48.73148,21.35 43.30926,20.29815 43.79815,14.52037 38.33148,16.66852 35.62037,11.75 z"
+       id="path6338" />
+    <path
+       id="path6318"
+       d="m 35.62037,10.138889 -3.02222,4.85926 -5.4074,-2.28148 0.6074,6.02963 -5.46667,0.99259 4,4.11852 -4.68148,4.42963 6.20741,0.99259 -0.97778,6.28148 5.54074,-2.9037 2.88889,5.48148 2.88889,-5.40741 5.17037,2.75556 -0.11852,-5.8963 5.6,-0.68149 -3.94074,-4.68147 3.82222,-4.48889 -5.42222,-1.05185 0.48889,-5.77778 -5.46667,2.14815 -2.71111,-4.91852 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-vnd.nintendo.snes.rom.svg
+++ b/src/vector/48x48/mimetypes/application-vnd.nintendo.snes.rom.svg
@@ -1,0 +1,1133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-vnd.nintendo.snes.rom.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         id="stop4568"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4570"
+         offset="1"
+         style="stop-color:#625c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4149">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4151" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         id="stop4129"
+         offset="0"
+         style="stop-color:#8f2b12;stop-opacity:1;" />
+      <stop
+         id="stop4131"
+         offset="1"
+         style="stop-color:#82461a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4134"
+       id="linearGradient4140"
+       x1="789"
+       y1="256"
+       x2="827"
+       y2="256"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4136" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4138" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4130">
+      <path
+         id="path4132"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5618"
+       id="linearGradient4083"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         style="stop-color:#3e3e3e;stop-opacity:1;"
+         offset="0"
+         id="stop5620" />
+      <stop
+         style="stop-color:#595959;stop-opacity:1;"
+         offset="1"
+         id="stop5622" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         style="stop-color:#dd2f03;stop-opacity:1;"
+         offset="0"
+         id="stop3936" />
+      <stop
+         style="stop-color:#e96300;stop-opacity:1;"
+         offset="1"
+         id="stop3938" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3177"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4149"
+       id="linearGradient4155"
+       x1="24"
+       y1="43.5"
+       x2="37"
+       y2="23.375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0"
+       id="linearGradient3998-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         id="stop4102"
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1;" />
+      <stop
+         id="stop4104"
+         offset="1"
+         style="stop-color:#767676;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4900"
+       gradientUnits="userSpaceOnUse"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         style="stop-color:#cd5fc2;stop-opacity:1;"
+         offset="0"
+         id="stop4086" />
+      <stop
+         style="stop-color:#9a4993;stop-opacity:1;"
+         offset="1"
+         id="stop4088" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         style="stop-color:#717171;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-3" />
+      <stop
+         style="stop-color:#848484;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4904"
+       gradientUnits="userSpaceOnUse"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3415" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3417" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4068">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4070"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4060">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4062"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3423">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3425"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3427">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3429"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3431">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3433"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3435">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3437"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3439">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3441"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3443">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3445"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-231.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-235.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3968"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3958"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3950"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3997"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop5144" />
+      <stop
+         id="stop5146"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5148" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5172"
+       xlink:href="#linearGradient3944"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4202"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="translate(-4.0000003,0)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3928">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         id="path3930"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(389,-66)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#a4a4a4;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#e6e6e6;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3523"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3505">
+      <stop
+         id="stop3507"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3509"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3491">
+      <stop
+         id="stop3493"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3495"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3477">
+      <stop
+         id="stop3479"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3481"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3463">
+      <stop
+         id="stop3465"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3467"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3449">
+      <stop
+         id="stop3451"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3453"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3435">
+      <stop
+         id="stop3437"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3439"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3421">
+      <stop
+         id="stop3423"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3425"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3407">
+      <stop
+         id="stop3409"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3411"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         id="stop3395"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3397"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3379">
+      <stop
+         id="stop3381"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3383"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3365">
+      <stop
+         id="stop3367"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3369"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3860">
+      <stop
+         id="stop3862"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3864"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3852">
+      <stop
+         id="stop3854"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3856"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="28"
+       x2="272"
+       y1="284"
+       x1="272"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4025"
+       xlink:href="#linearGradient3852"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-83">
+      <stop
+         id="stop3864-8-6-1"
+         offset="0"
+         style="stop-color:#03688e;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-40"
+         offset="1"
+         style="stop-color:#2396c1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3860-0">
+      <stop
+         id="stop3862-2"
+         offset="0"
+         style="stop-color:#1e23bf;stop-opacity:1;" />
+      <stop
+         id="stop3864-3"
+         offset="1"
+         style="stop-color:#0a12ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3852-1"
+       id="linearGradient4032-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-486.7,52.15889)"
+       x1="272"
+       y1="284"
+       x2="272"
+       y2="28" />
+    <linearGradient
+       id="linearGradient3852-1">
+      <stop
+         id="stop3854-9"
+         offset="0"
+         style="stop-color:#30b229;stop-opacity:1;" />
+      <stop
+         id="stop3856-8"
+         offset="1"
+         style="stop-color:#2cd324;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3987"
+       d="m 42.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4205);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4214);fill-opacity:1;stroke:none"
+       d="m 42,42 0,3 0.5,0 C 43.331,45 44,44.331 44,43.5 44,42.669 43.331,42 42.5,42 L 42,42 z"
+       id="rect3940"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3989"
+       d="M 4.4866072,41.000001 C 3.6630268,41.000001 3,42.045313 3,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4202);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4211);fill-opacity:1;stroke:none"
+       d="m 5.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+       id="rect3942"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4208);fill-opacity:1;stroke:none"
+       d="m 5.1141432,41 37.7717148,0 0,5 -37.7717148,0 z"
+       id="rect3985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+       d="m 5.9998568,42 36.0002842,0 0,3 -36.0002842,0 z"
+       id="rect3938"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient3877);fill-opacity:1.0;stroke:none;display:inline"
+       d="M 6.4375 5 C 5.625551 5 5 5.6255532 5 6.4375 L 5 41.5625 C 5 42.374447 5.625551 43 6.4375 43 L 41.5625 43 C 42.374449 43 43 42.374447 43 41.5625 L 43 6.4375 C 43 5.6255532 42.374449 5 41.5625 5 L 6.4375 5 z "
+       id="rect4073" />
+    <rect
+       style="opacity:0.41;fill:none;stroke:#000000;stroke-opacity:1;display:inline"
+       id="rect4085"
+       width="39"
+       height="39"
+       x="-43.5"
+       y="-43.5"
+       transform="matrix(0,-1,-1,0,0,0)"
+       ry="1.95"
+       rx="1.9499974" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.14999999999999999;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       d="M 6.4375,5.00002 C 5.62555,5.00002 5,5.62557 5,6.43752 l 0,1 C 5,6.62557 5.62555,6.00002 6.4375,6.00002 l 35.125,0 c 0.81195,0 1.4375,0.62555 1.4375,1.4375 l 0,-1 c 0,-0.81195 -0.62555,-1.4375 -1.4375,-1.4375 l -35.125,0 z"
+       id="rect4089-4" />
+    <path
+       transform="matrix(0,1,-1,0,280,-784)"
+       style="opacity:0.10000000000000001;fill:none;stroke:url(#linearGradient4140);stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+       id="path4128"
+       clip-path="url(#clipPath4130)"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4105"
+       d="M 6.4375,43.000017 C 5.62555,43.000017 5,42.374417 5,41.562517 L 5,40.56252 c 0,0.811897 0.62555,1.437497 1.4375,1.437497 l 35.125,0 c 0.81195,0 1.4375,-0.6256 1.4375,-1.437497 l 0,0.999997 c 0,0.8119 -0.62555,1.4375 -1.4375,1.4375 l -35.125,0 z"
+       style="opacity:0.10000000000000001;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-758.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-144.75488"
+         x="-758.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-651.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-144.75488"
+         x="-651.01172"
+         sodipodi:role="line"
+         id="tspan3937">zsnes</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-357.5"
+       y="-24.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-357.5"
+       y="-64.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-357.5"
+       y="-112.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-63.5"
+       x="-356.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="55.5"
+       x="-485.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-757.5"
+       y="-136.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-485.5"
+       y="-24.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-485.5"
+       y="-136.5"
+       inkscape:label="96x96" />
+    <g
+       id="g4996"
+       transform="translate(54.5,0)">
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new"
+         d="m -32.375,15.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.06361,-0.0037 0.150305,0 0.21875,0 2.717154,0 4.90625,2.214636 4.90625,4.9375 l 0,0.0625 0.25,-0.03125 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 L -30.5,25 l 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.125 0.21875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 0.1875,-0.125 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.1875 0.15625,-0.1875 0.15625,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.03125,-0.25 0.0625,-0.21875 0.03125,-0.25 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0624,-0.0037 0.123345,0 0.1875,0 2.643202,0 4.8125,2.132867 4.8125,4.78125 l 0,0.0625 0.21875,0 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.125 0.1875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 L -19,28.75 l 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.15625 0.125,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.0625,-0.1875 0.0625,-0.25 0.0625,-0.21875 L -17.5625,26 l 0.03125,-0.25 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,23.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,1.454963 2.324162,2.625 5.1875,2.625 2.867499,0 5.1875,-1.170037 5.1875,-2.625 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,1.523045 2.42727,2.75 5.4375,2.75 C -25.46008,34 -23,32.772349 -23,31.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         id="path4221"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4212"
+         d="m -32.375,14.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.06361,-0.0037 0.150305,0 0.21875,0 2.717154,0 4.90625,2.214636 4.90625,4.9375 l 0,0.0625 0.25,-0.03125 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 L -30.5,24 l 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.125 0.21875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 0.1875,-0.125 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.1875 0.15625,-0.1875 0.15625,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.03125,-0.25 0.0625,-0.21875 0.03125,-0.25 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0624,-0.0037 0.123345,0 0.1875,0 2.643202,0 4.8125,2.132867 4.8125,4.78125 l 0,0.0625 0.21875,0 0.25,-0.03125 0.21875,-0.03125 0.25,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.125 0.1875,-0.09375 0.1875,-0.125 0.1875,-0.125 0.1875,-0.125 0.1875,-0.15625 L -19,27.75 l 0.15625,-0.15625 0.15625,-0.15625 0.15625,-0.15625 0.125,-0.1875 0.125,-0.1875 0.125,-0.1875 0.09375,-0.1875 0.125,-0.21875 0.09375,-0.21875 0.0625,-0.21875 0.0625,-0.1875 0.0625,-0.25 0.0625,-0.21875 L -17.5625,25 l 0.03125,-0.25 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,22.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,1.454963 2.324162,2.625 5.1875,2.625 2.867499,0 5.1875,-1.170037 5.1875,-2.625 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,1.523045 2.42727,2.75 5.4375,2.75 C -25.46008,33 -23,31.772349 -23,30.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;fill:#bbbbbb;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4223"
+         d="m -32.375,14.375 c -2.465475,0.248118 -4.407632,2.317051 -4.4375,4.84375 0.03635,-0.0021 0.08129,-6.47e-4 0.125,0 0.449995,-2.057987 2.179304,-3.629072 4.3125,-3.84375 0.164365,-0.01654 0.331272,0 0.5,0 2.547993,0 4.65244,1.926511 4.90625,4.40625 l 0,-0.25 0.03125,-0.25 c 0,-2.717674 -2.219641,-4.90625 -4.9375,-4.90625 -0.168728,0 -0.335635,-0.01654 -0.5,0 z m 10.09375,5.09375 c -2.625875,0 -4.781328,2.127608 -4.8125,4.75 0.0312,-0.0019 0.06269,-4.63e-4 0.09375,0 0.48043,-2.1494 2.431506,-3.75 4.71875,-3.75 2.50088,0 4.528315,1.93225 4.75,4.375 l 0,-0.09375 0.03125,-0.21875 0,-0.25 c 0,-2.648393 -2.13113,-4.8125 -4.78125,-4.8125 z M -38.3125,22.75 l -0.28125,0.03125 -0.25,0 -0.25,0 -0.28125,0.03125 -0.25,0.03125 -0.21875,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.0625 -0.1875,0.0625 -0.21875,0.09375 -0.1875,0.0625 -0.15625,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.15625,0.09375 -0.15625,0.125 -0.125,0.09375 -0.125,0.09375 -0.125,0.125 -0.09375,0.125 -0.09375,0.125 -0.09375,0.09375 -0.0625,0.125 -0.0625,0.15625 -0.03125,0.125 -0.03125,0.125 -0.03125,0.125 0,0.125 c 0,0.171172 0.03232,0.338156 0.09375,0.5 l 0.0625,-0.15625 0.0625,-0.125 L -43.1875,25.5 -43.09375,25.375 -43,25.25 l 0.125,-0.125 0.125,-0.09375 0.125,-0.09375 0.15625,-0.125 0.15625,-0.09375 0.15625,-0.09375 0.1875,-0.09375 0.15625,-0.09375 0.1875,-0.0625 0.21875,-0.09375 0.1875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.0625 0.25,-0.03125 0.25,-0.0625 0.21875,-0.03125 0.25,-0.03125 0.28125,-0.03125 0.25,0 0.25,0 0.28125,-0.03125 c 2.509671,0 4.610607,0.89757 5.09375,2.09375 0.05407,-0.152354 0.09375,-0.308276 0.09375,-0.46875 0,-1.449772 -2.319304,-2.625 -5.1875,-2.625 z m 9.28125,4.75 -0.25,0.03125 -0.28125,0.03125 -0.28125,0.03125 -0.25,0.03125 -0.25,0.03125 -0.25,0.0625 -0.25,0.03125 -0.21875,0.0625 -0.21875,0.09375 -0.21875,0.0625 -0.21875,0.0625 -0.21875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.1875,0.09375 -0.15625,0.09375 -0.1875,0.09375 -0.125,0.125 -0.15625,0.09375 -0.125,0.125 -0.125,0.125 -0.125,0.125 -0.09375,0.125 -0.0625,0.125 -0.09375,0.125 -0.0625,0.125 -0.03125,0.15625 -0.03125,0.125 -0.03125,0.15625 0,0.125 c 0,0.149131 0.04894,0.29492 0.09375,0.4375 l 0.0625,-0.125 0.09375,-0.125 0.0625,-0.125 0.09375,-0.125 0.125,-0.125 0.125,-0.125 0.125,-0.125 0.15625,-0.09375 0.125,-0.125 0.1875,-0.09375 0.15625,-0.09375 0.1875,-0.09375 0.1875,-0.09375 0.1875,-0.09375 0.21875,-0.09375 0.21875,-0.0625 0.21875,-0.0625 0.21875,-0.09375 0.21875,-0.0625 0.25,-0.03125 0.25,-0.0625 0.25,-0.03125 0.25,-0.03125 0.28125,-0.03125 0.28125,-0.03125 0.25,-0.03125 0.28125,0 0.28125,0 c 2.676463,0 4.91245,0.962935 5.375,2.25 C -23.03634,30.590349 -23,30.418093 -23,30.25 c 0,-1.5239 -2.46008,-2.75 -5.46875,-2.75 l -0.28125,0 -0.28125,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;letter-spacing:normal;word-spacing:normal;text-anchor:start;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-x-gba-rom.svg
+++ b/src/vector/48x48/mimetypes/application-x-gba-rom.svg
@@ -1,0 +1,1214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-gba-rom.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         id="stop4568"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4570"
+         offset="1"
+         style="stop-color:#625c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4149">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4151" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         id="stop4129"
+         offset="0"
+         style="stop-color:#8f2b12;stop-opacity:1;" />
+      <stop
+         id="stop4131"
+         offset="1"
+         style="stop-color:#82461a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4134"
+       id="linearGradient4140"
+       x1="789"
+       y1="256"
+       x2="827"
+       y2="256"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4136" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4138" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4130">
+      <path
+         id="path4132"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5618"
+       id="linearGradient4083"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         style="stop-color:#3e3e3e;stop-opacity:1;"
+         offset="0"
+         id="stop5620" />
+      <stop
+         style="stop-color:#595959;stop-opacity:1;"
+         offset="1"
+         id="stop5622" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         style="stop-color:#dd2f03;stop-opacity:1;"
+         offset="0"
+         id="stop3936" />
+      <stop
+         style="stop-color:#e96300;stop-opacity:1;"
+         offset="1"
+         id="stop3938" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3177"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4149"
+       id="linearGradient4155"
+       x1="24"
+       y1="43.5"
+       x2="37"
+       y2="23.375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0"
+       id="linearGradient3998-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         id="stop4102"
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1;" />
+      <stop
+         id="stop4104"
+         offset="1"
+         style="stop-color:#767676;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4900"
+       gradientUnits="userSpaceOnUse"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         style="stop-color:#cd5fc2;stop-opacity:1;"
+         offset="0"
+         id="stop4086" />
+      <stop
+         style="stop-color:#9a4993;stop-opacity:1;"
+         offset="1"
+         id="stop4088" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         style="stop-color:#717171;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-3" />
+      <stop
+         style="stop-color:#848484;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4904"
+       gradientUnits="userSpaceOnUse"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231"
+       gradientTransform="translate(-3.5,-3.5)" />
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="0"
+         id="stop3415" />
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1;"
+         offset="1"
+         id="stop3417" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4068">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4070"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4060">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4062"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3423">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3425"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3427">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3429"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3431">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3433"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3435">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3437"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3439">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3441"
+         width="24"
+         height="9"
+         x="316"
+         y="240"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3443">
+      <rect
+         ry="4.5"
+         y="259"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3445"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(980.3622,784)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4084"
+       id="linearGradient4631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="324"
+       y1="231"
+       x2="324"
+       y2="273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="328"
+       y1="273"
+       x2="328"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.5,-3.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3413"
+       id="linearGradient4642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-231.5)"
+       x1="336"
+       y1="273"
+       x2="336"
+       y2="231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4100"
+       id="linearGradient4669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-307.5,-235.5)"
+       x1="328"
+       y1="235"
+       x2="328"
+       y2="277" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       x1="-1023.8622"
+       y1="-808"
+       x2="-984.86218"
+       y2="-808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#ededed;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3968"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3958"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3950"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3997"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop5144" />
+      <stop
+         id="stop5146"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5148" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5172"
+       xlink:href="#linearGradient3944"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4202"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="translate(-4.0000003,0)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3928">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         id="path3930"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-09"
+       id="linearGradient5057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient4868">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4870" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4872" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4861">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4863" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4854">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4856" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4858" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4847">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4849" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4851" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4840">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4842" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4844" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4833">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop4835" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop4837" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3911">
+      <stop
+         offset="0"
+         style="stop-color:#efedf5;stop-opacity:1;"
+         id="stop3913" />
+      <stop
+         offset="1"
+         style="stop-color:#c4c0d6;stop-opacity:1;"
+         id="stop3915" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-09">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#493479;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-16"
+         offset="1"
+         style="stop-color:#6b559e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-5"
+       xlink:href="#outerBackgroundGradient-09"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-1"
+         offset="0"
+         style="stop-color:#4c4c4c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-7"
+         offset="1"
+         style="stop-color:#737373;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4708"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4710"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4704"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4706"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4700"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4702"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4696"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4698"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4692"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4694"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4688"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4690"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4684"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4686"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4680"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4682"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4676"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4678"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath3246-2"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3248-9"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4670"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4672"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4666"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4668"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath4662"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4664"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <clipPath
+       id="clipPath3246"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3248"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#73a6e5;fill-opacity:1;stroke:none;font-family:Comic Sans MS;-inkscape-font-specification:Comic Sans MS"
+         d="m 324.53906,66.455078 c -0.24219,1.199221 -0.75196,2.158205 -1.52929,2.876953 -0.77345,0.714844 -1.68751,1.072265 -2.74219,1.072266 -0.96094,-10e-7 -1.68164,-0.267578 -2.16211,-0.802735 -0.48047,-0.539061 -0.7207,-1.345701 -0.7207,-2.419921 0,-1.011715 0.23828,-2.05273 0.71484,-3.123047 0.48047,-1.074212 1.0957,-1.941399 1.8457,-2.601563 0.5,-0.441397 1.0293,-0.6621 1.58789,-0.662109 0.35547,9e-6 0.82422,0.117196 1.40625,0.351562 0.71093,0.281259 1.0664,0.591806 1.06641,0.931641 -10e-6,0.160164 -0.0586,0.302742 -0.17578,0.427734 -0.1172,0.125008 -0.25782,0.187508 -0.42188,0.1875 -0.0859,8e-6 -0.20703,-0.04882 -0.36328,-0.146484 -0.59766,-0.363273 -1.10157,-0.544914 -1.51172,-0.544922 -0.29297,8e-6 -0.59961,0.152352 -0.91992,0.457031 -0.16016,0.152352 -0.39063,0.429695 -0.69141,0.832032 -0.90234,1.195318 -1.35351,2.492191 -1.35351,3.890625 0,0.734377 0.11328,1.248048 0.33984,1.541015 0.24609,0.320314 0.69922,0.48047 1.35938,0.480469 0.69921,10e-7 1.30663,-0.220702 1.82226,-0.662109 0.54297,-0.468748 0.92187,-1.13867 1.13672,-2.009766 -1.08203,0.05469 -2.00977,0.263675 -2.7832,0.626953 -0.0898,0.04297 -0.17774,0.06446 -0.26367,0.06445 -0.17188,3e-6 -0.31446,-0.0664 -0.42774,-0.199219 -0.10547,-0.12109 -0.1582,-0.261715 -0.1582,-0.421875 0,-0.21484 0.10351,-0.386714 0.31055,-0.515625 0.84374,-0.51562 2.29882,-0.773432 4.36523,-0.773437 0.16796,5e-6 0.30859,0.05665 0.42188,0.169922 0.11327,0.113286 0.16991,0.255864 0.16992,0.427734 -1e-5,0.25391 -0.10743,0.435551 -0.32227,0.544922" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#313131;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#535353;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-7"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         id="stop3864-8-6-7"
+         offset="0"
+         style="stop-color:#6da563;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-5-9"
+         offset="1"
+         style="stop-color:#84cc76;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3911"
+       id="linearGradient4121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66668359,0,0,0.66668359,-263.83842,-85.169899)"
+       x1="320"
+       y1="156"
+       x2="320"
+       y2="188" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3987"
+       d="m 42.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4205);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4214);fill-opacity:1;stroke:none"
+       d="m 42,42 0,3 0.5,0 C 43.331,45 44,44.331 44,43.5 44,42.669 43.331,42 42.5,42 L 42,42 z"
+       id="rect3940"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3989"
+       d="M 4.4866072,41.000001 C 3.6630268,41.000001 3,42.045313 3,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+       style="opacity:0.12000002;fill:url(#radialGradient4202);fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.12000002;fill:url(#radialGradient4211);fill-opacity:1;stroke:none"
+       d="m 5.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+       id="rect3942"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4208);fill-opacity:1;stroke:none"
+       d="m 5.1141432,41 37.7717148,0 0,5 -37.7717148,0 z"
+       id="rect3985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:0.12000002;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+       d="m 5.9998568,42 36.0002842,0 0,3 -36.0002842,0 z"
+       id="rect3938"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient3877);fill-opacity:1.0;stroke:none;display:inline"
+       d="M 6.4375 5 C 5.625551 5 5 5.6255532 5 6.4375 L 5 41.5625 C 5 42.374447 5.625551 43 6.4375 43 L 41.5625 43 C 42.374449 43 43 42.374447 43 41.5625 L 43 6.4375 C 43 5.6255532 42.374449 5 41.5625 5 L 6.4375 5 z "
+       id="rect4073" />
+    <rect
+       style="opacity:0.41;fill:none;stroke:#000000;stroke-opacity:1;display:inline"
+       id="rect4085"
+       width="39"
+       height="39"
+       x="-43.5"
+       y="-43.5"
+       transform="matrix(0,-1,-1,0,0,0)"
+       ry="1.95"
+       rx="1.9499974" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.14999999999999999;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       d="M 6.4375,5.00002 C 5.62555,5.00002 5,5.62557 5,6.43752 l 0,1 C 5,6.62557 5.62555,6.00002 6.4375,6.00002 l 35.125,0 c 0.81195,0 1.4375,0.62555 1.4375,1.4375 l 0,-1 c 0,-0.81195 -0.62555,-1.4375 -1.4375,-1.4375 l -35.125,0 z"
+       id="rect4089-4" />
+    <path
+       transform="matrix(0,1,-1,0,280,-784)"
+       style="opacity:0.10000000000000001;fill:none;stroke:url(#linearGradient4140);stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+       id="path4128"
+       clip-path="url(#clipPath4130)"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4105"
+       d="M 6.4375,43.000017 C 5.62555,43.000017 5,42.374417 5,41.562517 L 5,40.56252 c 0,0.811897 0.62555,1.437497 1.4375,1.437497 l 35.125,0 c 0.81195,0 1.4375,-0.6256 1.4375,-1.437497 l 0,0.999997 c 0,0.8119 -0.62555,1.4375 -1.4375,1.4375 l -35.125,0 z"
+       style="opacity:0.10000000000000001;fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-85.754883"
+       xml:space="preserve"
+       x="-756.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-85.754883"
+         x="-756.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-85.754883"
+       xml:space="preserve"
+       x="-649.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-85.754883"
+         x="-649.01172"
+         sodipodi:role="line"
+         id="tspan3937">gba</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-355.5"
+       y="34.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-355.5"
+       y="-5.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-355.5"
+       y="-53.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-4.5"
+       x="-354.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="114.5"
+       x="-483.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-755.5"
+       y="-77.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-483.5"
+       y="34.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-483.5"
+       y="-77.5"
+       inkscape:label="96x96" />
+    <g
+       id="g5011"
+       transform="translate(41,-6)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4240"
+         d="M -19.65625,18 C -20.394928,18 -21,18.605051 -21,19.34375 L -21,27 -28.65625,27 C -29.394949,27 -30,27.605072 -30,28.34375 l 0,5.3125 C -30,34.394928 -29.394949,35 -28.65625,35 L -21,35 l 0,7.65625 C -21,43.394949 -20.394928,44 -19.65625,44 l 5.34375,0 C -13.573822,44 -13,43.394949 -13,42.65625 L -13,35 l 7.6874997,0 c 0.738699,0 1.3125,-0.605072 1.3125,-1.34375 l 0,-5.3125 c 0,-0.738678 -0.573801,-1.34375 -1.3125,-1.34375 L -13,27 -13,19.34375 C -13,18.605051 -13.573822,18 -14.3125,18 l -5.34375,0 z M -19,21 l 4,0 -2,4 -2,-4 z m -8,8 4,2 -4,2 0,-4 z m 10,0 c 1.104598,0 2,0.895402 2,2 0,1.104598 -0.895402,2 -2,2 -1.104598,0 -2,-0.895402 -2,-2 0,-1.104598 0.895402,-2 2,-2 z m 9.9999997,0 0,4 L -11,31 -7.0000003,29 z M -17,37 l 2,4 -4,0 2,-4 z"
+         style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         style="color:#000000;fill:#bbbbbb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="M -19.65625,17 C -20.394928,17 -21,17.605051 -21,18.34375 L -21,26 -28.65625,26 C -29.394949,26 -30,26.605072 -30,27.34375 l 0,5.3125 C -30,33.394928 -29.394949,34 -28.65625,34 L -21,34 l 0,7.65625 C -21,42.394949 -20.394928,43 -19.65625,43 l 5.34375,0 C -13.573822,43 -13,42.394949 -13,41.65625 L -13,34 l 7.6874997,0 c 0.738699,0 1.3125,-0.605072 1.3125,-1.34375 l 0,-5.3125 c 0,-0.738678 -0.573801,-1.34375 -1.3125,-1.34375 L -13,26 -13,18.34375 C -13,17.605051 -13.573822,17 -14.3125,17 l -5.34375,0 z M -19,20 l 4,0 -2,4 -2,-4 z m -8,8 4,2 -4,2 0,-4 z m 10,0 c 1.104598,0 2,0.895402 2,2 0,1.104598 -0.895402,2 -2,2 -1.104598,0 -2,-0.895402 -2,-2 0,-1.104598 0.895402,-2 2,-2 z m 9.9999997,0 0,4 L -11,30 -7.0000003,28 z M -17,36 l 2,4 -4,0 2,-4 z"
+         id="path4238"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4227"
+         d="M -19.65625,17 C -20.394928,17 -21,17.605051 -21,18.34375 l 0,1 C -21,18.605051 -20.394928,18 -19.65625,18 l 5.34375,0 C -13.573822,18 -13,18.605051 -13,19.34375 l 0,-1 C -13,17.605051 -13.573822,17 -14.3125,17 l -5.34375,0 z M -19,21 l 2,4 2,-4 -0.5,0 -1.5,3 -1.5,-3 -0.5,0 z m -9.65625,5 C -29.394949,26 -30,26.605072 -30,27.34375 l 0,1 C -30,27.605072 -29.394949,27 -28.65625,27 L -21,27 l 0,-1 -7.65625,0 z M -13,26 l 0,1 7.6875,0 C -4.573801,27 -4,27.605072 -4,28.34375 l 0,-1 C -4,26.605072 -4.573801,26 -5.3125,26 L -13,26 z m -11,4.5 -3,1.5 0,1 4,-2 -1,-0.5 z m 5.0625,0 C -18.978603,30.659761 -19,30.827407 -19,31 c 0,1.104598 0.895402,2 2,2 1.104598,0 2,-0.895402 2,-2 0,-0.172593 -0.0214,-0.340239 -0.0625,-0.5 -0.221957,0.86271 -1.005495,1.5 -1.9375,1.5 -0.932005,0 -1.715543,-0.63729 -1.9375,-1.5 z m 8.9375,0 -1,0.5 4,2 0,-1 -3,-1.5 z m -8.5,9.5 -0.5,1 4,0 -0.5,-1 -3,0 z"
+         style="opacity:0.1;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-x-mobipocket-ebook.svg
+++ b/src/vector/48x48/mimetypes/application-x-mobipocket-ebook.svg
@@ -1,0 +1,2140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4045"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-mobipocket-ebook.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview112"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="-191.94838"
+     inkscape:cy="83.470291"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4045">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3106" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4047">
+    <linearGradient
+       id="linearGradient4439">
+      <stop
+         offset="0"
+         style="stop-color:#85b916;stop-opacity:1;"
+         id="stop4441" />
+      <stop
+         offset="1"
+         style="stop-color:#4c680d;stop-opacity:1;"
+         id="stop4443" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4433">
+      <stop
+         offset="0"
+         style="stop-color:#beeb5c;stop-opacity:1;"
+         id="stop4435" />
+      <stop
+         offset="1"
+         style="stop-color:#88b32d;stop-opacity:1;"
+         id="stop4437" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#d17b01;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#fc9501;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#6b440d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4043"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)" />
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient3080"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient3082"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)" />
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)" />
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)" />
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)" />
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3072-7"
+       xlink:href="#linearGradient3731-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)" />
+    <linearGradient
+       id="linearGradient3731-6">
+      <stop
+         id="stop3733-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3075-2"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5">
+      <stop
+         id="stop5430-8-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-4"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3077-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28">
+      <stop
+         id="stop5440-4-2"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-0"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7">
+      <stop
+         id="stop8969-1"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8971-3"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-6">
+      <stop
+         id="stop3321-9"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3323-0"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3085-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.275649,0)" />
+    <linearGradient
+       id="linearGradient2346-9">
+      <stop
+         id="stop2348-0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350-4"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3087-4"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9">
+      <stop
+         id="stop5440-4-8-1"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8-1"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient3090-9"
+       xlink:href="#linearGradient2346-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient3092-1"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-3">
+      <stop
+         id="stop2883-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-2"
+       xlink:href="#linearGradient3688-464-309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-0">
+      <stop
+         id="stop2889-3"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-7">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-5"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3927"
+       xlink:href="#linearGradient3702-501-757-7"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="24.501682"
+       cy="6.6475959"
+       r="17.49832"
+       fx="24.501682"
+       fy="6.6475959"
+       id="radialGradient4085"
+       xlink:href="#linearGradient8967-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)" />
+    <linearGradient
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758"
+       id="linearGradient4087"
+       xlink:href="#linearGradient3319-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636"
+       id="linearGradient4681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636">
+      <stop
+         id="stop4638"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4640"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3993"
+       xlink:href="#linearGradient4636"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,89.5,122.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4499"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,377.5,394.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4496"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,417.5,362.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4493"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,465.5,322.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4490"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,169.5,378.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4487"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,361.5,234.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4484"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,249.5,314.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4481"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4478"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4476"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4474"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4348"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4346"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4344"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4342"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4340"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4338"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4336"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4254"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-12,300)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4256"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,276,572)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4260"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,364,500)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4262"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,68,556)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4264"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,260,412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient4266"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,148,492)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="linearGradient3870"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         style="stop-color:#c01914;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6" />
+      <stop
+         style="stop-color:#d4231e;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-0">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-8" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         style="stop-color:#e5523c;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-2" />
+      <stop
+         style="stop-color:#ed8879;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4349-1">
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="0"
+         id="stop4351-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4353-81" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4636-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-6" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-2"
+       xlink:href="#linearGradient4636-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient4087-4"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-1"
+       id="radialGradient4085-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-8"
+       id="linearGradient3927-9"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-2" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-1"
+       id="radialGradient3015-2-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-3" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-6"
+       id="radialGradient3013-6-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-2"
+       id="linearGradient3092-1-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3090-9-9"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-3" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-9"
+       id="linearGradient3087-4-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-6">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-6"
+       id="linearGradient3085-9-4"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-6"
+       id="linearGradient3077-8-3"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-7" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-6" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-4"
+       id="radialGradient3075-2-8"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-5">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-7" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-1" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-5"
+       id="linearGradient3072-7-5"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3092-7"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3090-8"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3087-8"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3085-8"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3082-2"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3080-1"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3077-6"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3075-3"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-7"
+       id="linearGradient3072-9"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient4043-6"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-6">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-6" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-1" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-4" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3015-8"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3013-7"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-8" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-94">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-7" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-69">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-6" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-9">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-0" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-89" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-2" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-5" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-5" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-3" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-9" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749-2"
+       id="radialGradient3639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient3641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757-6"
+       id="linearGradient3643"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3645"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3647"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346-94"
+       id="linearGradient3649"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-5"
+       id="linearGradient3651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-2"
+       id="radialGradient3653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663731,-113.07083)"
+       cx="24.501682"
+       cy="6.6475959"
+       fx="24.501682"
+       fy="6.6475959"
+       r="17.49832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789307,-49.124425)"
+       x1="32.901409"
+       y1="4.6481781"
+       x2="32.901409"
+       y2="61.481758" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-8"
+       id="radialGradient3657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-8"
+       id="linearGradient3659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-6"
+       id="linearGradient3661"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4636-2"
+       id="linearGradient3993-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,46.974576,2.1230056)"
+       x1="3"
+       y1="25"
+       x2="42"
+       y2="24.5" />
+    <linearGradient
+       id="linearGradient4636-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4638-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4640-0" />
+    </linearGradient>
+    <linearGradient
+       y2="24.5"
+       x2="42"
+       y1="25"
+       x1="3"
+       gradientTransform="matrix(0,1,-1,0,49,1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4681-6"
+       xlink:href="#linearGradient4636-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,-55.196714,-0.12442511)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-4"
+       id="linearGradient4087-3"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,-11.611914,-64.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-7-6"
+       id="radialGradient4085-5"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-7-1"
+       id="linearGradient3927-0"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-7-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-3-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-5-5" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-8-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-0-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-3-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-5-21" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-0-2"
+       id="radialGradient3015-2-1"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-3-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-5-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-1-02" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-3-8"
+       id="radialGradient3013-6-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,-55.121499,-0.05165168)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-6-4"
+       id="linearGradient3092-1-02"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,-56.052371,-4.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-9"
+       id="linearGradient3090-9-7"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-1-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,-55.275388,0.03848905)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-9-0"
+       id="linearGradient3087-4-1"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2346-9-9">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-0-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-4-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-57.275649,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-9-9"
+       id="linearGradient3085-9-3"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       id="linearGradient3319-6-4">
+      <stop
+         offset="0"
+         style="stop-color:#96bf3e;stop-opacity:1"
+         id="stop3321-9-7" />
+      <stop
+         offset="1"
+         style="stop-color:#4d6b0d;stop-opacity:1"
+         id="stop3323-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-7-6">
+      <stop
+         offset="0"
+         style="stop-color:#c4ea71;stop-opacity:1"
+         id="stop8969-1-0" />
+      <stop
+         offset="1"
+         style="stop-color:#7c9d35;stop-opacity:1"
+         id="stop8971-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-2-4" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-0-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,-55.275648,-1.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-28-0"
+       id="linearGradient3077-8-2"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-7">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-8-0" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-4-2" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-1-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,-10.385546,-14.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-5-7"
+       id="radialGradient3075-2-4"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       id="linearGradient3731-6-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-9-6" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-8-5" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-3-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-2-03" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,-54.681053,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-6-2"
+       id="linearGradient3072-7-7"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.7162781,0,0,0.7471593,2.1541503,0.94834832)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-5"
+       id="linearGradient3092-0"
+       y2="0.065301567"
+       x2="54.887218"
+       y1="0.065301567"
+       x1="5.2122574" />
+    <linearGradient
+       gradientTransform="matrix(1.0040453,0,0,1.5380658,1.2232785,-3.0400179)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-7"
+       id="linearGradient3090-97"
+       y2="4.882647"
+       x2="24.640038"
+       y1="3.1234391"
+       x1="24.62738" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.10256346,2.0002611,1.038489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-0"
+       id="linearGradient3087-0"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <linearGradient
+       gradientTransform="translate(0,1)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2346-7"
+       id="linearGradient3085-7"
+       y2="3"
+       x2="10.654308"
+       y1="1"
+       x1="10.654308" />
+    <linearGradient
+       gradientTransform="matrix(0.7007108,0,0,0.73712869,2.0789348,0.87557489)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3319-5"
+       id="linearGradient3082-27"
+       y2="61.481758"
+       x2="32.901409"
+       y1="4.6481781"
+       x1="32.901409" />
+    <radialGradient
+       gradientTransform="matrix(0,2.744544,-3.1834145,0,45.663735,-63.070829)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8967-92"
+       id="radialGradient3080-7"
+       fy="6.6475959"
+       fx="24.501682"
+       r="17.49832"
+       cy="6.6475959"
+       cx="24.501682" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.0512821,2.0000013,-0.2307699)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-82"
+       id="linearGradient3077-7"
+       y2="3.8990016"
+       x2="24"
+       y1="44"
+       x1="24" />
+    <radialGradient
+       gradientTransform="matrix(1.9428467e-8,2.4568358,-2.4722567,-4.5264291e-8,46.890103,-13.303252)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-9"
+       id="radialGradient3075-7"
+       fy="8.4497671"
+       fx="7.4956832"
+       r="19.99999"
+       cy="8.4497671"
+       cx="7.4956832" />
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.0540541,2.5945964,-1.2972859)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3731-0"
+       id="linearGradient3072-8"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-2"
+       id="linearGradient4043-3"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-2">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-35" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-81">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-6" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-81"
+       id="radialGradient3015-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-4">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-8" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-65" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-4"
+       id="radialGradient3013-73"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2-0">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-8-6" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-8-33" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2346-7">
+      <stop
+         offset="0"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         id="stop2348-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         id="stop2350-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3319-5">
+      <stop
+         offset="0"
+         style="stop-color:#fc9501;stop-opacity:1"
+         id="stop3321-8" />
+      <stop
+         offset="1"
+         style="stop-color:#6b440d;stop-opacity:1"
+         id="stop3323-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967-92">
+      <stop
+         offset="0"
+         style="stop-color:#ffbd5d;stop-opacity:1"
+         id="stop8969-11" />
+      <stop
+         offset="1"
+         style="stop-color:#d17b01;stop-opacity:1"
+         id="stop8971-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-82">
+      <stop
+         offset="0"
+         style="stop-color:#272727;stop-opacity:1"
+         id="stop5440-4-1" />
+      <stop
+         offset="1"
+         style="stop-color:#454545;stop-opacity:1"
+         id="stop5442-3-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         id="stop5430-8-3" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         id="stop5432-3-1" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         id="stop5434-1-0" />
+      <stop
+         offset="1"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         id="stop5436-8-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3731-0">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3733-8" />
+      <stop
+         offset="0.02706478"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3735-91" />
+      <stop
+         offset="0.97377032"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3737-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3739-6" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.0526316,0,0,0.57142859,-1.2631579,20.642856)"
+     id="g3712"
+     style="opacity:0.4">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801"
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700"
+       style="fill:url(#linearGradient4043);fill-opacity:1;stroke:none" />
+  </g>
+  <path
+     d="M 40.838991,4.217154 C 40.543588,3.2259354 40.727705,2.4453462 40.56455,1.4999998 l -30.239763,0 0.178478,3"
+     id="path2723"
+     style="fill:url(#linearGradient3090);fill-opacity:1;stroke:url(#linearGradient3092);stroke-width:1.01739752;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 11.50026,5.4999996 -4.0000002,0 c -0.5708481,0 -1,-0.042333 -1,-0.09756 l 0,-2.7964211 c 0,-0.8879195 0.5590322,-1.1059935 1.2908943,-1.1059935 l 3.7091059,0"
+     id="rect5505-21-3-9"
+     style="color:#000000;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3087);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="33.977596"
+     height="40.980957"
+     rx="1"
+     ry="1"
+     x="7.5128837"
+     y="4.5095215"
+     id="rect2719"
+     style="fill:url(#radialGradient3080);fill-opacity:1.0;stroke:url(#linearGradient3082);stroke-width:1.01904118000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     d="m 11.5,4.4999998 c 0,0 0,28.5091172 0,41.0000002 l -4,0 c -0.5708481,0 -1,-0.43395 -1,-1 l 0,-40.0000002 z"
+     id="rect5505-21-3"
+     style="color:#000000;fill:url(#radialGradient3075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3077);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:0.2;fill:url(#linearGradient3993);fill-opacity:1;stroke:none"
+     d="m 7,5 0,40 33,0 1,0 0,-40 -1,0 z m 1,1 32,0 0,38 -32,0 z"
+     id="path3893"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     style="fill:#000000;fill-opacity:1;opacity:0.2"
+     transform="matrix(0.03718204,0,0,0.03718204,16.42073,16.643264)"
+     id="g4458">
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g4460" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;display:inline"
+       d="m 293.596,233.97 c 0,26.322 0.627,48.264 -12.651,71.65 -10.724,19.022 -27.791,30.698 -46.749,30.698 -25.905,0 -41.069,-19.73 -41.069,-48.979 0,-57.525 51.607,-67.983 100.469,-67.983 v 14.614 z m 68.105,164.685 c -4.48,4.005 -10.934,4.283 -15.971,1.567 -22.446,-18.64 -26.462,-27.263 -38.718,-45.009 -37.07,37.767 -63.335,49.094 -111.356,49.094 -56.871,0 -101.09,-35.085 -101.09,-105.269 0,-54.833 29.688,-92.112 72.023,-110.394 36.647,-16.086 87.836,-19.004 127.006,-23.397 v -8.774 c 0,-16.074 1.253,-35.091 -8.218,-48.979 -8.217,-12.43 -24.013,-17.542 -37.905,-17.542 -25.76,0 -48.67,13.196 -54.288,40.552 -1.178,6.094 -5.612,12.11 -11.745,12.425 l -65.459,-7.092 c -5.524,-1.241 -11.676,-5.682 -10.074,-14.119 C 120.942,42.297 192.668,18.3 256.943,18.3 c 32.857,0 75.823,8.774 101.729,33.63 32.857,30.71 29.7,71.65 29.7,116.248 v 105.223 c 0,31.65 13.138,45.543 25.487,62.615 4.317,6.128 5.292,13.44 -0.209,17.92 -13.8,11.571 -38.324,32.869 -51.811,44.87 l -0.138,-0.151 z m 92.56,18.722 c -62.721,26.602 -130.884,39.461 -192.884,39.461 -91.933,0 -180.924,-25.209 -252.882,-67.096 -6.302,-3.668 -10.968,2.797 -5.733,7.532 66.702,60.236 154.845,96.425 252.732,96.425 69.846,0 150.949,-21.971 206.903,-63.254 9.249,-6.847 1.323,-17.084 -8.136,-13.068 z m 16.701,50.278 c -2.043,5.106 2.345,7.172 6.964,3.296 30.014,-25.116 37.767,-77.716 31.615,-85.317 -6.093,-7.532 -58.565,-14.021 -90.599,8.461 -4.921,3.481 -4.062,8.24 1.394,7.59 18.036,-2.17 58.182,-6.986 65.343,2.183 7.149,9.168 -7.962,46.911 -14.717,63.787 z"
+       id="path4462" />
+  </g>
+  <g
+     id="7935ec95c421cee6d86eb22ecd1149e3"
+     transform="matrix(0.03718204,0,0,0.03718204,16.42073,15.643533)"
+     style="fill:#ffffff;fill-opacity:1">
+    <g
+       id="g3434"
+       style="fill:#ffffff;fill-opacity:1" />
+    <path
+       id="path3436"
+       d="m 293.596,233.97 c 0,26.322 0.627,48.264 -12.651,71.65 -10.724,19.022 -27.791,30.698 -46.749,30.698 -25.905,0 -41.069,-19.73 -41.069,-48.979 0,-57.525 51.607,-67.983 100.469,-67.983 v 14.614 z m 68.105,164.685 c -4.48,4.005 -10.934,4.283 -15.971,1.567 -22.446,-18.64 -26.462,-27.263 -38.718,-45.009 -37.07,37.767 -63.335,49.094 -111.356,49.094 -56.871,0 -101.09,-35.085 -101.09,-105.269 0,-54.833 29.688,-92.112 72.023,-110.394 36.647,-16.086 87.836,-19.004 127.006,-23.397 v -8.774 c 0,-16.074 1.253,-35.091 -8.218,-48.979 -8.217,-12.43 -24.013,-17.542 -37.905,-17.542 -25.76,0 -48.67,13.196 -54.288,40.552 -1.178,6.094 -5.612,12.11 -11.745,12.425 l -65.459,-7.092 c -5.524,-1.241 -11.676,-5.682 -10.074,-14.119 C 120.942,42.297 192.668,18.3 256.943,18.3 c 32.857,0 75.823,8.774 101.729,33.63 32.857,30.71 29.7,71.65 29.7,116.248 v 105.223 c 0,31.65 13.138,45.543 25.487,62.615 4.317,6.128 5.292,13.44 -0.209,17.92 -13.8,11.571 -38.324,32.869 -51.811,44.87 l -0.138,-0.151 z m 92.56,18.722 c -62.721,26.602 -130.884,39.461 -192.884,39.461 -91.933,0 -180.924,-25.209 -252.882,-67.096 -6.302,-3.668 -10.968,2.797 -5.733,7.532 66.702,60.236 154.845,96.425 252.732,96.425 69.846,0 150.949,-21.971 206.903,-63.254 9.249,-6.847 1.323,-17.084 -8.136,-13.068 z m 16.701,50.278 c -2.043,5.106 2.345,7.172 6.964,3.296 30.014,-25.116 37.767,-77.716 31.615,-85.317 -6.093,-7.532 -58.565,-14.021 -90.599,8.461 -4.921,3.481 -4.062,8.24 1.394,7.59 18.036,-2.17 58.182,-6.986 65.343,2.183 7.149,9.168 -7.962,46.911 -14.717,63.787 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;display:inline"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-x-qtiplot.svg
+++ b/src/vector/48x48/mimetypes/application-x-qtiplot.svg
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-qtiplot.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="17.933368"
+     inkscape:cy="22.527889"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       y2="-984"
+       x2="317"
+       y1="-939"
+       x1="317"
+       gradientTransform="matrix(1.0833333,0,0,0.88888892,-330.50001,878.16672)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3886"
+       xlink:href="#linearGradient20553"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient20553">
+      <stop
+         style="stop-color:#a348b1;stop-opacity:1;"
+         offset="0"
+         id="stop20555" />
+      <stop
+         style="stop-color:#bf7bca;stop-opacity:1;"
+         offset="1"
+         id="stop20557" />
+    </linearGradient>
+    <linearGradient
+       y2="-984"
+       x2="317"
+       y1="-939"
+       x1="317"
+       gradientTransform="matrix(1.0833333,0,0,0.88888892,-269.25001,808.66672)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4136"
+       xlink:href="#linearGradient20553"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-8"
+       id="linearGradient3996"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="4"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-8"
+       id="linearGradient3996-2"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="4"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         style="stop-color:#36d4af;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-49" />
+      <stop
+         style="stop-color:#1da5fd;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-36" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20,3)"
+       y2="4"
+       x2="24"
+       y1="44"
+       x1="24"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4789"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 7.5 3.5 L 7.5 4 L 7.5 43 L 7.5 43.5 L 8 43.5 L 40 43.5 L 40.5 43.5 L 40.5 43 L 40.5 4 L 40.5 3.5 L 40 3.5 L 8 3.5 L 7.5 3.5 z "
+       id="rect3882" />
+    <path
+       style="opacity:1;fill:url(#linearGradient3996);fill-opacity:1.0;stroke:none"
+       d="m 7.5,3.5 0,4 0,36 5.5,0 0,-35.5 27.5,0 0,-4.5 -28,0 z"
+       id="rect3955"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.1;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       id="path3968"
+       d="M 7.5 3.5 L 7.5 4 L 7.5 43 L 7.5 43.5 L 8 43.5 L 40 43.5 L 40.5 43.5 L 40.5 43 L 40.5 4 L 40.5 3.5 L 40 3.5 L 8 3.5 L 7.5 3.5 z "
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.41" />
+    <rect
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       id="rect4003"
+       width="5.5"
+       height="4.4990802"
+       x="7.5"
+       y="3.5009198" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <path
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 12 4 L 12 7 L 8 7 L 8 8 L 12 8 L 12 12 L 8 12 L 8 13 L 12 13 L 12 17 L 8 17 L 8 18 L 12 18 L 12 22 L 8 22 L 8 23 L 12 23 L 12 27 L 8 27 L 8 28 L 12 28 L 12 32 L 8 32 L 8 33 L 12 33 L 12 37 L 8 37 L 8 38 L 12 38 L 12 43 L 13 43 L 13 38 L 20 38 L 20 43 L 21 43 L 21 38 L 28 38 L 28 43 L 29 43 L 29 38 L 36 38 L 36 43 L 37 43 L 37 38 L 40 38 L 40 37 L 37 37 L 37 33 L 40 33 L 40 32 L 37 32 L 37 28 L 40 28 L 40 27 L 37 27 L 37 23 L 40 23 L 40 22 L 37 22 L 37 18 L 40 18 L 40 17 L 37 17 L 37 13 L 40 13 L 40 12 L 37 12 L 37 8 L 40 8 L 40 7 L 37 7 L 37 4 L 36 4 L 36 7 L 29 7 L 29 4 L 28 4 L 28 7 L 21 7 L 21 4 L 20 4 L 20 7 L 13 7 L 13 4 L 12 4 z M 13 8 L 20 8 L 20 12 L 13 12 L 13 8 z M 21 8 L 28 8 L 28 12 L 21 12 L 21 8 z M 29 8 L 36 8 L 36 12 L 29 12 L 29 8 z M 13 13 L 20 13 L 20 17 L 13 17 L 13 13 z M 21 13 L 28 13 L 28 17 L 21 17 L 21 13 z M 29 13 L 36 13 L 36 17 L 29 17 L 29 13 z M 13 18 L 20 18 L 20 22 L 13 22 L 13 18 z M 21 18 L 28 18 L 28 22 L 21 22 L 21 18 z M 29 18 L 36 18 L 36 22 L 29 22 L 29 18 z M 13 23 L 20 23 L 20 27 L 13 27 L 13 23 z M 21 23 L 28 23 L 28 27 L 21 27 L 21 23 z M 29 23 L 36 23 L 36 27 L 29 27 L 29 23 z M 13 28 L 20 28 L 20 32 L 13 32 L 13 28 z M 21 28 L 28 28 L 28 32 L 21 32 L 21 28 z M 29 28 L 36 28 L 36 32 L 29 32 L 29 28 z M 13 33 L 20 33 L 20 37 L 13 37 L 13 33 z M 21 33 L 28 33 L 28 37 L 21 37 L 21 33 z M 29 33 L 36 33 L 36 37 L 29 37 L 29 33 z "
+       id="rect3209" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-x-wine-extension-skb.svg
+++ b/src/vector/48x48/mimetypes/application-x-wine-extension-skb.svg
@@ -1,0 +1,2347 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-wine-extension-skp.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="38.4919"
+     inkscape:cy="-36.360318"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3865">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3867" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3869" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880">
+      <stop
+         id="stop4882"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop4884"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:0.61" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient4688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         style="stop-color:#389fca;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#36acf4;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-61.529053,48.769197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4308"
+       xlink:href="#outerBackgroundGradient-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928"
+       id="linearGradient4868"
+       x1="24"
+       y1="48"
+       x2="24"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient3871"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16"
+       gradientTransform="matrix(2,0,0,2,-24,-24)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient7886"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient3432">
+      <stop
+         id="stop3434"
+         offset="0"
+         style="stop-color:#d7312c;stop-opacity:1;" />
+      <stop
+         id="stop3436"
+         offset="1"
+         style="stop-color:#f44f4a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-89"
+       xlink:href="#linearGradient3432"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-67"
+       id="linearGradient7855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.2105866e-7,-3.999999)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-67">
+      <stop
+         id="stop3864-8-6-6"
+         offset="0"
+         style="stop-color:#1d0100;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#4a2826;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-53"
+         offset="0"
+         style="stop-color:#805024;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-0"
+         offset="1"
+         style="stop-color:#e19043;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#0e52ab;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-6"
+         offset="1"
+         style="stop-color:#1ec49c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#3689e6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#90dbec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#65b11b;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#88da38;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4451"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4449"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3900"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3898"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3922"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3948"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3946"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4020"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4018"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3996"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3994"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3972"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4131">
+      <stop
+         id="stop4133"
+         offset="0"
+         style="stop-color:#8b2b28;stop-opacity:1;" />
+      <stop
+         id="stop4135"
+         offset="1"
+         style="stop-color:#cb2c31;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3970"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7220"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7218"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7216"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7214"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7212"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7210"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7208"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,214.29595,368.40292)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,326.29595,288.40292)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,430.29595,376.40292)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,382.29595,416.40292)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,342.29595,448.40292)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4180"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,54.295953,176.40292)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3039"
+       id="linearGradient4347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-212.52905,-72.230803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3039">
+      <stop
+         style="stop-color:#7767ad;stop-opacity:1"
+         offset="0"
+         id="stop3041" />
+      <stop
+         style="stop-color:#a594df;stop-opacity:1"
+         offset="1"
+         id="stop3043" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-5"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7742">
+      <stop
+         style="stop-color:#ffa622;stop-opacity:1;"
+         offset="0"
+         id="stop7744" />
+      <stop
+         style="stop-color:#ffbd52;stop-opacity:1;"
+         offset="1"
+         id="stop7746" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4684"
+       xlink:href="#linearGradient7742"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-0">
+      <stop
+         id="stop3864-8-6-9-8"
+         offset="0"
+         style="stop-color:#24ade7;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-9"
+         offset="1"
+         style="stop-color:#52cbfe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-8"
+       xlink:href="#outerBackgroundGradient-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928-3">
+      <stop
+         id="stop5930-7"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-1"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-3"
+       id="linearGradient7127-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-8" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-6"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-1"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-3">
+      <stop
+         id="stop4691-0"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-3"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-8"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-8"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-1"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-9"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-9"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-6"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880-3">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop4882-8" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:0.61"
+         offset="1"
+         id="stop4884-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient5124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-1"
+       id="linearGradient7888"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <clipPath
+       id="clipPath7848"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7850"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7844"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7846"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7840"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7842"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7836"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7838"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7832"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7834"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7828"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7830"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7824"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7826"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7820"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7822"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7816"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7818"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7812"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7814"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7808"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7810"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7804"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7806"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath7800"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path7802"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <clipPath
+       id="clipPath5812"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="m 302,290 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         sodipodi:ry="8"
+         sodipodi:rx="8"
+         sodipodi:cy="290"
+         sodipodi:cx="294"
+         id="path5815"
+         style="opacity:0.5;color:#bebebe;fill:#dddddd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-1">
+      <stop
+         id="stop3864-8-6-52"
+         offset="0"
+         style="stop-color:#363a32;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-75"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-23"
+       xlink:href="#outerBackgroundGradient-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4105">
+      <stop
+         style="stop-color:#092b51;stop-opacity:1;"
+         offset="0"
+         id="stop4107" />
+      <stop
+         style="stop-color:#1772ca;stop-opacity:1;"
+         offset="1"
+         id="stop4109" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-7"
+       xlink:href="#linearGradient4105"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-2">
+      <stop
+         id="stop3864-8-6-460"
+         offset="0"
+         style="stop-color:#bcbcbc;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1-8"
+         offset="1"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(-288,-316)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-0"
+       xlink:href="#outerBackgroundGradient-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-30">
+      <stop
+         id="stop3864-8-6-5-9"
+         offset="0"
+         style="stop-color:#940005;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-70"
+         offset="1"
+         style="stop-color:#b11c21;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2-6"
+       xlink:href="#outerBackgroundGradient-30"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-4">
+      <stop
+         id="stop3864-8-6-46"
+         offset="0"
+         style="stop-color:#0068c6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#2888e0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8-8"
+       xlink:href="#outerBackgroundGradient-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(1.6692749e-6,-3.9999995)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4228"
+       xlink:href="#outerBackgroundGradient-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-9">
+      <stop
+         id="stop3864-8-6-4-1"
+         offset="0"
+         style="stop-color:#7395b9;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-7"
+         offset="1"
+         style="stop-color:#8fb3d9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       id="linearGradient4258"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4235"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.61907"
+       x2="283.80957"
+       y1="299.80954"
+       x1="283.80957"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3881"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="7"
+         y="53"
+         x="417"
+         height="30"
+         width="30"
+         id="rect3883"
+         style="color:#bebebe;fill:url(#linearGradient3885);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="28.571428"
+       x2="286.85715"
+       y1="302.85715"
+       x1="286.85715"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3875"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3871"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient3875);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3873"
+         width="22"
+         height="22"
+         x="417"
+         y="101"
+         ry="5" />
+    </clipPath>
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4350"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4346"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="18"
+         y="32"
+         x="292"
+         height="88"
+         width="88"
+         id="rect4348"
+         style="color:#bebebe;fill:url(#linearGradient4350);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="140"
+       x2="352"
+       y1="204"
+       x1="352"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4199"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28"
+       x2="384"
+       y1="124"
+       x1="384"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4197"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140"
+       x2="352"
+       y1="204"
+       x1="352"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4191"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4187"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient4191);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4189"
+         width="60"
+         height="60"
+         x="290"
+         y="142"
+         ry="12.5" />
+    </clipPath>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-6"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40"
+       x2="144"
+       y1="280"
+       x1="144"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3866"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3862"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient3866);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3864"
+         width="220"
+         height="220"
+         x="34"
+         y="46"
+         ry="50" />
+    </clipPath>
+    <linearGradient
+       y2="40.00005"
+       x2="144"
+       y1="280.00003"
+       x1="144"
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,302.4,209.33333)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3859"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3855"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         ry="3"
+         y="212"
+         x="304"
+         height="16"
+         width="16"
+         id="rect3857"
+         style="color:#bebebe;fill:url(#linearGradient3859);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="40.00005"
+       x2="149.71432"
+       y1="291.42862"
+       x1="149.71432"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,430.13636,32.227267)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4093"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4089"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="6"
+         y="37"
+         x="433"
+         height="30"
+         width="30"
+         id="rect4091"
+         style="color:#bebebe;fill:url(#linearGradient4093);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       y2="40.000046"
+       x2="149.71428"
+       y1="291.42862"
+       x1="149.71428"
+       gradientTransform="matrix(0.0875,0,0,0.0875,430.9,81.499996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4048"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4044"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:url(#linearGradient4048);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4046"
+         width="22"
+         height="22"
+         x="433"
+         y="85"
+         ry="4" />
+    </clipPath>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,302.79999,215.99997)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4895"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4891"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         style="color:#bebebe;fill:url(#linearGradient4895);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4893"
+         width="42"
+         height="42"
+         x="307"
+         y="223"
+         ry="9" />
+    </clipPath>
+    <linearGradient
+       y2="22.857315"
+       x2="281.14291"
+       y1="297.14304"
+       x1="281.14291"
+       gradientTransform="matrix(0.175,0,0,-0.175,286.79999,-215.99997)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4869"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="31.61907"
+       x2="283.80957"
+       y1="299.80954"
+       x1="283.80957"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4153"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="28.571428"
+       x2="286.85715"
+       y1="302.85715"
+       x1="286.85715"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,414.4,137.33333)"
+       y2="40.00005"
+       x2="264"
+       y1="280.00003"
+       x1="264"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097"
+       xlink:href="#outerBackgroundGradient-63"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-63">
+      <stop
+         id="stop3864-8-6-2"
+         offset="0"
+         style="stop-color:#7469b3;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-753"
+         offset="1"
+         style="stop-color:#a6afe2;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       id="filter7554"
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend7556"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5608" />
+    </linearGradient>
+    <filter
+       id="filter7554-8"
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always">
+      <feBlend
+         mode="darken"
+         in2="BackgroundImage"
+         id="feBlend7556-3"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5608-8" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5606-8">
+      <stop
+         id="stop5608-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5374"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5376"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,9.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5388"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-40,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-64,-24)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5440"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5446"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,9.987521,-65.730803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-40,-60)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-64,-84)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient5512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient5514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient5516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient5518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-65.730803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient5520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-60)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient5522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-24,-84)"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.2;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4870"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#2d6493;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.81" />
+    <path
+       style="opacity:0.2;fill:url(#radialGradient3871);fill-opacity:1;stroke:none"
+       d="m 10,4 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 z m 1,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z"
+       id="rect3813"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <g
+       id="g5126">
+      <path
+         style="opacity:0.2;fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         id="path4344"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path14126-7"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </g>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="81.302788"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-103.85196"
+         x="81.302788"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="188.78424"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-103.85196"
+         x="188.78424"
+         sodipodi:role="line"
+         id="tspan3937">sketchup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="482.29596"
+       y="16.40292"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="482.29596"
+       y="-23.59708"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="482.29596"
+       y="-71.597076"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-22.59708"
+       x="483.29596"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="96.402924"
+       x="354.29596"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="82.295952"
+       y="-95.597076"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="354.29596"
+       y="16.40292"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="354.29596"
+       y="-95.597076"
+       inkscape:label="96x96" />
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-802.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context-6"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-144.75488"
+         x="-802.49316"
+         sodipodi:role="line"
+         id="tspan3933-5">apps</tspan></text>
+    <text
+       y="-144.75488"
+       xml:space="preserve"
+       x="-695.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name-4"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-144.75488"
+         x="-695.01172"
+         sodipodi:role="line"
+         id="tspan3937-1">deja-dup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16-9"
+       width="16"
+       height="16"
+       x="-401.5"
+       y="-24.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24-5"
+       width="24"
+       height="24"
+       x="-401.5"
+       y="-64.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32-5"
+       width="32"
+       height="32"
+       x="-401.5"
+       y="-112.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-63.5"
+       x="-400.5"
+       height="22"
+       width="22"
+       id="rect22x22-9"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="55.5"
+       x="-529.5"
+       height="48"
+       width="48"
+       id="rect48x48-9"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256-6"
+       width="256"
+       height="256"
+       x="-801.5"
+       y="-136.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64-0"
+       width="64"
+       height="64"
+       x="-529.5"
+       y="-24.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96-6"
+       width="96"
+       height="96"
+       x="-529.5"
+       y="-136.5"
+       inkscape:label="96x96" />
+    <g
+       id="g4857"
+       transform="matrix(0.58168969,0,0,0.58168969,6.8471048,22.423906)">
+      <g
+         transform="translate(20,0)"
+         id="g4085" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.2;color:#bebebe;fill:none;stroke:#ffffff;stroke-width:0.78246051;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path3106"
+         sodipodi:cx="290"
+         sodipodi:cy="295.5"
+         sodipodi:rx="3"
+         sodipodi:ry="2.5"
+         d="m 293,295.5 c 0,1.38071 -1.34315,2.5 -3,2.5 -1.65685,0 -3,-1.11929 -3,-2.5 0,-1.38071 1.34315,-2.5 3,-2.5 1.65685,0 3,1.11929 3,2.5 z"
+         transform="matrix(2.5070663,0,0,3.0084762,-682.089,-865.66565)" />
+      <g
+         transform="translate(20,0)"
+         id="g4080">
+        <path
+           sodipodi:type="arc"
+           style="color:#bebebe;fill:none;stroke:#ffffff;stroke-width:0.78246129;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           id="path3108"
+           sodipodi:cx="290"
+           sodipodi:cy="295.5"
+           sodipodi:rx="3"
+           sodipodi:ry="2.5"
+           d="m 287.00003,295.51059 c -0.007,-1.3807 1.33042,-2.50472 2.98726,-2.51057 1.65684,-0.006 3.00566,1.10869 3.01268,2.48939 0.007,1.37732 -1.32413,2.49992 -2.97689,2.51052"
+           transform="matrix(2.5070663,0,0,3.0084762,-702.089,-865.66565)"
+           sodipodi:start="3.1373554"
+           sodipodi:end="7.8462895"
+           sodipodi:open="true" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
+           d="m 287,294 -3.05714,-5.02858 6.05714,0 z"
+           id="path3110"
+           inkscape:connector-curvature="0"
+           transform="matrix(1.074457,0,0,1.074457,-290.93013,-288.25338)"
+           sodipodi:nodetypes="cccc"
+           clip-path="url(#clipPath5812)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/application-x-wine-extension-skp.svg
+++ b/src/vector/48x48/mimetypes/application-x-wine-extension-skp.svg
@@ -1,0 +1,1264 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="application-x-wine-extension-skb.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="23.668756"
+     inkscape:cy="-11.797722"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3865">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3867" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3869" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880">
+      <stop
+         id="stop4882"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop4884"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:0.61" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-3"
+       id="linearGradient4688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="outerBackgroundGradient-3">
+      <stop
+         style="stop-color:#389fca;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6-9" />
+      <stop
+         style="stop-color:#36acf4;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-61.529053,48.769197)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4308"
+       xlink:href="#outerBackgroundGradient-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928"
+       id="linearGradient4868"
+       x1="24"
+       y1="48"
+       x2="24"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="radialGradient3871"
+       cx="24"
+       cy="24"
+       fx="24"
+       fy="24"
+       r="16"
+       gradientTransform="matrix(2,0,0,2,-24,-24)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient7886"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="linearGradient3432">
+      <stop
+         id="stop3434"
+         offset="0"
+         style="stop-color:#d7312c;stop-opacity:1;" />
+      <stop
+         id="stop3436"
+         offset="1"
+         style="stop-color:#f44f4a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-89"
+       xlink:href="#linearGradient3432"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-67"
+       id="linearGradient7855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.2105866e-7,-3.999999)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-67">
+      <stop
+         id="stop3864-8-6-6"
+         offset="0"
+         style="stop-color:#1d0100;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#4a2826;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-2"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-53"
+         offset="0"
+         style="stop-color:#805024;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-0"
+         offset="1"
+         style="stop-color:#e19043;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-8"
+       xlink:href="#outerBackgroundGradient-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-9">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#0e52ab;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-6"
+         offset="1"
+         style="stop-color:#1ec49c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#3689e6;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#90dbec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-5"
+         offset="0"
+         style="stop-color:#65b11b;stop-opacity:1" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#88da38;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4451"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4449"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3900"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3898"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3922"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3948"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3946"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4020"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4018"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3996"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3994"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3972"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4131">
+      <stop
+         id="stop4133"
+         offset="0"
+         style="stop-color:#8b2b28;stop-opacity:1;" />
+      <stop
+         id="stop4135"
+         offset="1"
+         style="stop-color:#cb2c31;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="397"
+       y1="133"
+       x1="397"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3970"
+       xlink:href="#linearGradient4131"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="172"
+       x2="349"
+       y1="172"
+       x1="291"
+       gradientTransform="matrix(0,-1,1,0,148,492)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7220"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="76"
+       x2="379"
+       y1="76"
+       x1="293"
+       gradientTransform="matrix(0,-1,1,0,260,412)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7218"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7216"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="68"
+       x2="446"
+       y1="68"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,364,500)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7214"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="112"
+       x2="438"
+       y1="112"
+       x1="418"
+       gradientTransform="matrix(0,-1,1,0,316,540)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7212"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="148"
+       x2="431"
+       y1="148"
+       x1="417"
+       gradientTransform="matrix(0,-1,1,0,276,572)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7210"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="156"
+       x2="253"
+       y1="156"
+       x1="35"
+       gradientTransform="matrix(0,-1,1,0,-12,300)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7208"
+       xlink:href="#outerBackgroundGradient-67"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,214.29595,368.40292)"
+       x1="291"
+       y1="172"
+       x2="349"
+       y2="172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,326.29595,288.40292)"
+       x1="293"
+       y1="76"
+       x2="379"
+       y2="76" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,430.29595,376.40292)"
+       x1="418"
+       y1="68"
+       x2="446"
+       y2="68" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,382.29595,416.40292)"
+       x1="418"
+       y1="112"
+       x2="438"
+       y2="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,342.29595,448.40292)"
+       x1="417"
+       y1="148"
+       x2="431"
+       y2="148" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient4180"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,54.295953,176.40292)"
+       x1="35"
+       y1="156"
+       x2="253"
+       y2="156" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3039"
+       id="linearGradient4347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-212.52905,-72.230803)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       id="linearGradient3039">
+      <stop
+         style="stop-color:#7767ad;stop-opacity:1"
+         offset="0"
+         id="stop3041" />
+      <stop
+         style="stop-color:#a594df;stop-opacity:1"
+         offset="1"
+         id="stop3043" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-5"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7742">
+      <stop
+         style="stop-color:#ffa622;stop-opacity:1;"
+         offset="0"
+         id="stop7744" />
+      <stop
+         style="stop-color:#ffbd52;stop-opacity:1;"
+         offset="1"
+         id="stop7746" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4684"
+       xlink:href="#linearGradient7742"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-3-0">
+      <stop
+         id="stop3864-8-6-9-8"
+         offset="0"
+         style="stop-color:#24ade7;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-9-9"
+         offset="1"
+         style="stop-color:#52cbfe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.18064516,0,0,0.17948718,-51.029053,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4688-8"
+       xlink:href="#outerBackgroundGradient-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928-3">
+      <stop
+         id="stop5930-7"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-1"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-3"
+       id="linearGradient7127-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-8" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-6"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-1"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-3">
+      <stop
+         id="stop4691-0"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-3"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-8"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-8"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-1"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-9"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.18046875,0,0,0.17948718,49.987521,-5.7308027)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-9"
+       xlink:href="#linearGradient3039"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-6"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4880-3">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop4882-8" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:0.61"
+         offset="1"
+         id="stop4884-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3432"
+       id="linearGradient5124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,134.29595,432.40292)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.2;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4870"
+       d="m 40.5,3.5 -33,0 0,40 33,0 z"
+       style="color:#bebebe;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#2d6493;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.81" />
+    <path
+       style="opacity:0.20000000000000001;fill:url(#radialGradient3871);fill-opacity:1;stroke:none"
+       d="m 10,4 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,3 -2,0 0,1 2,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 3,0 0,4 1,0 0,-4 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 1,0 0,-1 -1,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 -1,0 0,3 -3,0 0,-3 z m 1,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m -24,4 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z m 4,0 3,0 0,3 -3,0 z"
+       id="rect3813"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="81.302788"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-103.85196"
+         x="81.302788"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-103.85196"
+       xml:space="preserve"
+       x="188.78424"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-103.85196"
+         x="188.78424"
+         sodipodi:role="line"
+         id="tspan3937">sketchup</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="482.29596"
+       y="16.40292"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="482.29596"
+       y="-23.59708"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="482.29596"
+       y="-71.597076"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-22.59708"
+       x="483.29596"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="96.402924"
+       x="354.29596"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="82.295952"
+       y="-95.597076"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="354.29596"
+       y="16.40292"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="354.29596"
+       y="-95.597076"
+       inkscape:label="96x96" />
+    <g
+       id="g5126">
+      <path
+         style="opacity:0.2;fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         id="path4344"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path14126-7"
+         d="M 27.168752,16.094683 15,17.639963 15.869387,19.558976 24.679873,18.254895 27.865854,21.53895 33,20.637754 27.168752,16.094683 z m -2.385508,5.802094 -8.381095,1.426005 0.816377,2.144308 4.558975,-0.861435 1.168901,2.022383 4.829329,-1.041672 -2.992487,-3.689589 z m -2.743341,6.777495 -4.145484,0.909148 0.79517,2.321897 4.474157,-1.131795 -1.123843,-2.09925 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/text-x-markdown.svg
+++ b/src/vector/48x48/mimetypes/text-x-markdown.svg
@@ -1,0 +1,2263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-markdown.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.057935"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       id="linearGradient5928-0">
+      <stop
+         id="stop5930-2"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-5"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-0"
+       id="linearGradient7127-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-2">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-1" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-6">
+      <stop
+         id="stop4673-4"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-07"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-8">
+      <stop
+         id="stop4691-34"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-8"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-5"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-1"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-2"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-2"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-7"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-01"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-5"
+       xlink:href="#linearGradient3914-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-5"
+       xlink:href="#linearGradient3988-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-7"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-98"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-94"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-80">
+      <stop
+         id="stop3962-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-6" />
+      <stop
+         id="stop3964-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-93"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4274"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-360,-81.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-310.79998,-86.500033)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-2"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-3"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-6"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-4"
+       xlink:href="#linearGradient3988-5-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-82">
+      <stop
+         id="stop3990-5-37"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-72"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-57"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-16"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-71" />
+      <stop
+         id="stop3964-79"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4411"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4413"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4415"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4420"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-351.74399,-38.548621)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-302.54397,-43.548654)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       gradientTransform="translate(-4.0000003,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4214"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4211"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4208"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4205"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4202"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-9"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-45"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-10"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-90"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-4"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-90">
+      <stop
+         id="stop3962-76"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-3"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-75"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-8"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-1"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3877"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-5"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4736"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4738"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4744"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background"
+     style="display:inline">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.4;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       d="M 34.269233,17 H 13.730767 C 12.776413,17 12,17.776414 12,18.730768 V 30.269232 C 12,31.223634 12.776413,32 13.730767,32 H 34.269233 C 35.223634,32 36,31.223634 36,30.269232 V 18.730768 C 36,17.776414 35.223634,17 34.269233,17 z M 25.5,28.997068 l -3,0.0027 v -4.5 L 20.25,27.384416 18,24.4998 v 4.5 h -3 v -9 h 3 l 2.25,3 2.25,-3 3,-0.0027 v 9 z m 4.478693,0.75 L 26.25,24.5 H 28.5 V 20 h 3 v 4.5 h 2.25 l -3.771307,5.247068 z"
+       id="path3519"
+       style="fill:#ffffff;opacity:0.4" />
+    <path
+       id="path3510"
+       d="M 34.269233,16 H 13.730767 C 12.776413,16 12,16.776414 12,17.730768 V 29.269232 C 12,30.223634 12.776413,31 13.730767,31 H 34.269233 C 35.223634,31 36,30.223634 36,29.269232 V 17.730768 C 36,16.776414 35.223634,16 34.269233,16 z M 25.5,27.997068 l -3,0.0027 v -4.5 L 20.25,26.384416 18,23.4998 v 4.5 h -3 v -9 h 3 l 2.25,3 2.25,-3 3,-0.0027 v 9 z m 4.478693,0.75 L 26.25,23.5 H 28.5 V 19 h 3 v 4.5 h 2.25 l -3.771307,5.247068 z"
+       inkscape:connector-curvature="0"
+       style="fill:#cccccc;fill-opacity:1" />
+    <path
+       d="M 13.71875,16 C 12.764396,16 12,16.764396 12,17.71875 l 0,1 C 12,17.764396 12.764396,17 13.71875,17 l 20.5625,0 C 35.235651,17 36,17.764396 36,18.71875 l 0,-1 C 36,16.764396 35.235651,16 34.28125,16 l -20.5625,0 z M 18,23.5 l 0,1 2.25,2.875 2.25,-2.875 0,-1 -2.25,2.875 L 18,23.5 z m 8.25,1 3.71875,5.25 3.78125,-5.25 -0.71875,0 -3.0625,4.25 -3,-4.25 -0.71875,0 z M 15,28 l 0,1 3,0 0,-1 -3,0 z m 7.5,0 0,1 3,0 0,-1 -3,0 z"
+       id="path3521"
+       inkscape:connector-curvature="0"
+       style="opacity:0.1;fill:#000000" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol"
+     style="display:inline">
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/text-x-ms-regedit.svg
+++ b/src/vector/48x48/mimetypes/text-x-ms-regedit.svg
@@ -1,0 +1,2267 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-ms-regedit.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="16.541667"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       id="linearGradient5928-0">
+      <stop
+         id="stop5930-2"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-5"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-0"
+       id="linearGradient7127-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-2">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-1" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-6">
+      <stop
+         id="stop4673-4"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-07"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-8">
+      <stop
+         id="stop4691-34"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-8"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-5"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-1"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-2"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-2"
+       xlink:href="#linearGradient3960-80"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-7"
+       xlink:href="#linearGradient3952-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-01"
+       xlink:href="#linearGradient3944-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-5"
+       xlink:href="#linearGradient3914-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-5"
+       xlink:href="#linearGradient3988-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-8">
+      <stop
+         id="stop3990-5-7"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-98"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-94"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-80">
+      <stop
+         id="stop3962-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-6" />
+      <stop
+         id="stop3964-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-93"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-80"
+       id="linearGradient4266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-1"
+       id="radialGradient4268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-3"
+       id="radialGradient4270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4274"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-9"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-360,-81.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-8"
+       id="linearGradient4282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-310.79998,-86.500033)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-2"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-5"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-0"
+       xlink:href="#linearGradient3960-0"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-3"
+       xlink:href="#linearGradient3952-3"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-4"
+       xlink:href="#linearGradient3944-57"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-6"
+       xlink:href="#linearGradient3914-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-4"
+       xlink:href="#linearGradient3988-5-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-82">
+      <stop
+         id="stop3990-5-37"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-72"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-57"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-16"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-71" />
+      <stop
+         id="stop3964-79"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-0"
+       id="linearGradient4407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-3"
+       id="radialGradient4409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-57"
+       id="radialGradient4411"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4413"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4415"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-0"
+       id="linearGradient4420"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(-351.74399,-38.548621)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-82"
+       id="linearGradient4423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,-302.54397,-43.548654)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       gradientTransform="translate(-4.0000003,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,2,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4214"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-3.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4211"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0571429,0,0,1.6666667,-5.4000003,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4208"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,0.6,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4205"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-4.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4202"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-9"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-45"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-10"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-90"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-4"
+       xlink:href="#linearGradient3952-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-90">
+      <stop
+         id="stop3962-76"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-3" />
+      <stop
+         id="stop3964-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-3"
+       xlink:href="#linearGradient3960-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-75"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-8"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-1"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="matrix(0,-1,-1,0,-784,-980.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3877"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-5"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-5">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4736"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4738"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4744"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background"
+     style="display:inline">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.4;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol"
+     style="display:inline">
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+    <g
+       id="g5011"
+       transform="translate(-80,-2)">
+      <path
+         id="rect4926"
+         d="M 112,14.75 107.75,19 112,23.25 116.25,19 112,14.75 z M 94,17 l 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -7,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -14,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z"
+         style="opacity:0.4;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4680"
+         d="M 112,13.75 107.75,18 112,22.25 116.25,18 112,13.75 z M 94,16 l 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -7,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m -14,7 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z m 7,0 0,6 6,0 0,-6 -6,0 z"
+         style="color:#000000;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5004"
+         d="m 112,13.75 -4.25,4.25 0.5,0.5 3.75,-3.75 3.75,3.75 0.5,-0.5 L 112,13.75 z M 94,16 l 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m -7,7 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -1.75,0 L 112,23.25 111.75,23 108,23 z m -14,7 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z m 7,0 0,1 6,0 0,-1 -6,0 z"
+         style="opacity:0.1;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/src/vector/48x48/mimetypes/text-x-tex.svg
+++ b/src/vector/48x48/mimetypes/text-x-tex.svg
@@ -1,0 +1,1805 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3759"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="text-x-tex.svg"
+   inkscape:export-filename="/home/sam/faba-internet-mail.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     id="namedview36"
+     showgrid="false"
+     showborder="false"
+     inkscape:zoom="1"
+     inkscape:cx="66.75822"
+     inkscape:cy="18.931965"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata37">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3761">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0"
+         id="stop3962" />
+      <stop
+         id="stop3970"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3964" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5">
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0"
+         id="stop3990-5" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3992-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient3934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient3940"
+       gradientUnits="userSpaceOnUse"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)" />
+    <linearGradient
+       id="linearGradient4689">
+      <stop
+         style="stop-color:#5a9fd4;stop-opacity:1"
+         offset="0"
+         id="stop4691" />
+      <stop
+         style="stop-color:#306998;stop-opacity:1"
+         offset="1"
+         id="stop4693" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671">
+      <stop
+         style="stop-color:#ffec3b;stop-opacity:1;"
+         offset="0"
+         id="stop4673" />
+      <stop
+         style="stop-color:#ffe62e;stop-opacity:1;"
+         offset="1"
+         id="stop4675" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8085">
+      <stop
+         id="stop8087"
+         offset="0"
+         style="stop-color:#37a12e;stop-opacity:1;" />
+      <stop
+         id="stop8089"
+         offset="1"
+         style="stop-color:#54bc43;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="-52"
+       x2="816"
+       y1="-92"
+       x1="816"
+       gradientTransform="translate(-784.11538,94.500053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7127"
+       xlink:href="#linearGradient5928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5928">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop5930" />
+      <stop
+         style="stop-color:#3a77b9;stop-opacity:1;"
+         offset="1"
+         id="stop5932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-6"
+       id="linearGradient7077"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.8146973e-6,-4)"
+       x1="272"
+       y1="288"
+       x2="272"
+       y2="32" />
+    <linearGradient
+       id="outerBackgroundGradient-6">
+      <stop
+         id="stop3864-8-6-06"
+         offset="0"
+         style="stop-color:#252525;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-3"
+         offset="1"
+         style="stop-color:#4a4d42;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-4"
+       xlink:href="#outerBackgroundGradient-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0">
+      <stop
+         id="stop3864-8-6-8"
+         offset="0"
+         style="stop-color:#80b60c;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-1"
+         offset="1"
+         style="stop-color:#a8de33;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876-1"
+       xlink:href="#outerBackgroundGradient-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         id="stop3864-8-6"
+         offset="0"
+         style="stop-color:#930000;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1"
+         offset="1"
+         style="stop-color:#d11212;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="272"
+       y1="288"
+       x1="272"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3876"
+       xlink:href="#outerBackgroundGradient"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath3861"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3863"
+         style="fill:url(#linearGradient3865);fill-opacity:1;stroke:none"
+         d="m 144.00149,83.848805 c -44.164869,0 -80.381087,29.743555 -79.998488,66.334715 0.557476,53.87363 68.581098,73.25013 98.534728,64.26175 18.53624,6.07952 23.10984,13.75792 50.28704,13.70566 C 197.07593,217.78613 197.3926,211.46444 197.26483,200.26348 213.36689,188.13422 224,169.62117 224,150.18352 224,113.59036 188.16636,83.848806 144.00149,83.848805 z" />
+    </clipPath>
+    <linearGradient
+       id="outerBackgroundGradient-8">
+      <stop
+         id="stop3864-8-6-0"
+         offset="0"
+         style="stop-color:#2e7da0;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-4"
+         offset="1"
+         style="stop-color:#82cfeb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="25"
+       y1="45"
+       x2="25"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3960-9"
+       y2="42"
+       id="linearGradient3968" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="40"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3958" />
+    <radialGradient
+       r="2"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952-6"
+       id="radialGradient3950" />
+    <linearGradient
+       x1="144"
+       y1="280"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.2,-6)"
+       x2="144"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       id="linearGradient3158">
+      <stop
+         offset="0"
+         style="stop-color:#ededed"
+         id="stop3990-5-0" />
+      <stop
+         offset="1"
+         style="stop-color:#fafafa"
+         id="stop3992-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-6">
+      <stop
+         offset="0"
+         id="stop3954-1" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3956-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-9">
+      <stop
+         offset="0"
+         style="stop-opacity:0"
+         id="stop3962-6" />
+      <stop
+         offset=".5"
+         id="stop3970-4" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop3964-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-8">
+      <stop
+         id="stop5930-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-6"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-8"
+       id="linearGradient7127-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-8">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-0" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-7">
+      <stop
+         id="stop4673-2"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-0"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-7">
+      <stop
+         id="stop4691-3"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-0"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3940-9"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3937-0"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3934-3"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931-8"
+       xlink:href="#linearGradient3960-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3928-5"
+       xlink:href="#linearGradient3952-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3925-0"
+       xlink:href="#linearGradient3944-5"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="24"
+       y1="0"
+       x1="24"
+       id="linearGradient3920-2"
+       xlink:href="#linearGradient3914-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142-6"
+       xlink:href="#linearGradient3988-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-5">
+      <stop
+         id="stop3990-5-3"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-7"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-8">
+      <stop
+         id="stop3962-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-7" />
+      <stop
+         id="stop3964-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3914-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3916-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3918-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960-8"
+       id="linearGradient4978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952-7"
+       id="radialGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-5"
+       id="radialGradient4982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5-5"
+       id="linearGradient4984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,49.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914-6"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <clipPath
+       id="clipPath3928"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3930"
+         d="m 23.59375,11 c -0.24042,0.02284 -0.55561,0.07591 -0.8125,0.1875 0,0 -0.155265,0.541084 -0.28125,1.90625 -0.154301,1.669684 -0.799704,2.127709 -1.28125,2.46875 -0.481527,0.341022 -0.632092,0.417929 -0.8125,0.5 -0.943522,0.158386 -1.803896,0.258993 -3.09375,-0.8125 -1.054262,-0.875952 -1.5,-1.15625 -1.5,-1.15625 -0.520428,0.204398 -0.96875,0.75 -0.96875,0.75 0,0 -0.576035,0.447208 -0.78125,0.96875 0,0 0.311567,0.477007 1.1875,1.53125 1.071549,1.28978 0.970571,2.119258 0.8125,3.0625 -0.0817,0.179926 -0.190246,0.330768 -0.53125,0.8125 -0.340985,0.481713 -0.767853,1.126726 -2.4375,1.28125 -1.364962,0.126263 -1.875,0.28125 -1.875,0.28125 C 10.995319,23.29581 11,24 11,24 c 0,0 -0.0041,0.705025 0.21875,1.21875 0,0 0.509852,0.155822 1.875,0.28125 1.66961,0.154487 2.096199,0.79976 2.4375,1.28125 0.341301,0.481472 0.44955,0.632334 0.53125,0.8125 0.158757,0.943503 0.258937,1.804026 -0.8125,3.09375 -0.875934,1.054485 -1.1875,1.5 -1.1875,1.5 0.205958,0.521505 0.78125,1 0.78125,1 0,0 0.447375,0.544952 0.96875,0.75 0,0 0.445757,-0.279723 1.5,-1.15625 1.289854,-1.0714 2.150414,-0.969977 3.09375,-0.8125 0.180482,0.08189 0.330638,0.159052 0.8125,0.5 0.48188,0.340892 1.126726,0.767908 1.28125,2.4375 0.126078,1.36498 0.28125,1.875 0.28125,1.875 C 23.295736,37.004161 24,37 24,37 c 0,0 0.70523,0.0041 1.21875,-0.21875 0,0 0.155637,-0.509592 0.28125,-1.875 0.154487,-1.669592 0.784328,-2.100729 1.5625,-2.65625 l 0,-0.0625 c 0.184196,-0.06889 0.350972,-0.13705 0.53125,-0.21875 0.943447,-0.158757 1.772627,-0.258992 3.0625,0.8125 1.054261,0.875952 1.53125,1.15625 1.53125,1.15625 0.521597,-0.206162 0.96875,-0.75 0.96875,-0.75 0,0 0.544896,-0.478569 0.75,-1 0,0 -0.279537,-0.44572 -1.15625,-1.5 -1.071549,-1.28978 -0.970199,-2.150581 -0.8125,-3.09375 0.08189,-0.180482 0.181112,-0.315785 0.25,-0.5 l 0.0625,0 C 32.804909,26.31452 33.236585,25.654524 34.90625,25.5 36.271324,25.373922 36.8125,25.21875 36.8125,25.21875 37.035615,24.704245 37,24 37,24 c 0,0 0.03569,-0.704747 -0.1875,-1.21875 0,0 -0.541009,-0.155451 -1.90625,-0.28125 -1.669759,-0.154302 -2.100747,-0.783659 -2.65625,-1.5625 -0.06889,-0.184196 -0.230206,-0.35112 -0.3125,-0.53125 -0.158386,-0.94315 -0.259012,-1.772645 0.8125,-3.0625 0.875952,-1.054298 1.15625,-1.53125 1.15625,-1.53125 -0.20581,-0.521375 -0.75,-0.96875 -0.75,-0.96875 0,0 -0.447338,-0.544896 -0.96875,-0.75 0,0 -0.476598,0.279741 -1.53125,1.15625 -1.289817,1.071567 -2.067265,0.970349 -3.21875,0.46875 C 26.286034,15.217169 25.654357,14.763545 25.5,13.09375 25.373737,11.72875 25.21875,11.1875 25.21875,11.1875 24.704375,10.963902 23.999982,11 24,11 c 0,0 -0.165885,-0.02284 -0.40625,0 z M 24,18 c 3.313708,0 6,2.686292 6,6 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new" />
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944-1"
+       id="radialGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4001"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <radialGradient
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3999"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5142">
+      <stop
+         id="stop5144"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop5146" />
+      <stop
+         id="stop5148"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3997"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3944-1"
+       inkscape:collect="always">
+      <stop
+         id="stop3946-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3948-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="9"
+       cy="43.5"
+       cx="9"
+       id="radialGradient3950-6"
+       xlink:href="#linearGradient3944-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3952-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3954-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,0,10.875)"
+       r="2"
+       fy="43.5"
+       fx="40"
+       cy="43.5"
+       cx="40"
+       id="radialGradient3958-8"
+       xlink:href="#linearGradient3952-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3960-5">
+      <stop
+         id="stop3962-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-78" />
+      <stop
+         id="stop3964-78"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="42"
+       x2="25"
+       y1="45"
+       x1="25"
+       id="linearGradient3968-7"
+       xlink:href="#linearGradient3960-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3988-5-0">
+      <stop
+         id="stop3990-5-1"
+         offset="0"
+         style="stop-color:#ededed;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-0"
+         offset="1"
+         style="stop-color:#fafafa;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.000172"
+       x2="144.00006"
+       y1="280.00018"
+       x1="144.00006"
+       gradientTransform="matrix(0.175,0,0,0.175,-1.20002,-6.0000326)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3158-4"
+       xlink:href="#linearGradient3988-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-307.5,-235.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4669"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-307.5,-231.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4642"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4635"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4633"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4631"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientTransform="translate(-3.5,-3.5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4629"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4564"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient-0-3"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-223.5,332.5)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <clipPath
+       id="clipPath3443"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3445"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3439"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3441"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3435"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3437"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath3431"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3433"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3427"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect3429"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <clipPath
+       id="clipPath3423"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect3425"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4060"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="4.5"
+         y="240"
+         x="316"
+         height="9"
+         width="24"
+         id="rect4062"
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath4068"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         style="color:#bebebe;fill:#525252;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4070"
+         width="24"
+         height="9"
+         x="316"
+         y="259"
+         ry="4.5" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3413">
+      <stop
+         id="stop3415"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3417"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="336"
+       y1="273"
+       x1="336"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4904"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-7">
+      <stop
+         id="stop3864-8-6-3"
+         offset="0"
+         style="stop-color:#717171;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-2"
+         offset="1"
+         style="stop-color:#848484;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="231"
+       x2="328"
+       y1="273"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4902"
+       xlink:href="#linearGradient3413"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4084">
+      <stop
+         id="stop4086"
+         offset="0"
+         style="stop-color:#cd5fc2;stop-opacity:1;" />
+      <stop
+         id="stop4088"
+         offset="1"
+         style="stop-color:#9a4993;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="273"
+       x2="324"
+       y1="231"
+       x1="324"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4900"
+       xlink:href="#linearGradient4084"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4100">
+      <stop
+         style="stop-color:#aaaaaa;stop-opacity:1;"
+         offset="0"
+         id="stop4102" />
+      <stop
+         style="stop-color:#767676;stop-opacity:1;"
+         offset="1"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.5,-3.5)"
+       y2="277"
+       x2="328"
+       y1="235"
+       x1="328"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4100"
+       inkscape:collect="always" />
+    <linearGradient
+       id="outerBackgroundGradient-0-3">
+      <stop
+         id="stop3864-8-6-9"
+         offset="0"
+         style="stop-color:#dddddd;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-5"
+         offset="1"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998-0"
+       xlink:href="#outerBackgroundGradient-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.375"
+       x2="37"
+       y1="43.5"
+       x1="24"
+       id="linearGradient4155"
+       xlink:href="#linearGradient4149"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4117"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3934"
+       id="linearGradient3177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,65,302)"
+       x1="292"
+       y1="244"
+       x2="332"
+       y2="244" />
+    <linearGradient
+       id="linearGradient3934">
+      <stop
+         id="stop3936"
+         offset="0"
+         style="stop-color:#dd2f03;stop-opacity:1;" />
+      <stop
+         id="stop3938"
+         offset="1"
+         style="stop-color:#e96300;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="244"
+       x2="332"
+       y1="244"
+       x1="292"
+       gradientTransform="matrix(0,-1,1,0,68,556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3998"
+       xlink:href="#linearGradient3934"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5618">
+      <stop
+         id="stop5620"
+         offset="0"
+         style="stop-color:#3e3e3e;stop-opacity:1;" />
+      <stop
+         id="stop5622"
+         offset="1"
+         style="stop-color:#595959;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(980.3622,784)"
+       gradientUnits="userSpaceOnUse"
+       y2="-808"
+       x2="-984.86218"
+       y1="-808"
+       x1="-1023.8622"
+       id="linearGradient4083"
+       xlink:href="#linearGradient5618"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4130"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ba2222;fill-opacity:1;stroke:none"
+         d="M 790.4375,237 C 789.62555,237 789,237.62555 789,238.4375 l 0,35.09375 c 0,0.812 0.62555,1.46875 1.4375,1.46875 l 35.125,0 c 0.81195,0 1.4375,-0.65675 1.4375,-1.46875 l 0,-35.09375 C 827,237.62555 826.37445,237 825.5625,237 l -35.125,0 z"
+         id="path4132" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4134"
+       inkscape:collect="always">
+      <stop
+         id="stop4136"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4138"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="256"
+       x2="827"
+       y1="256"
+       x1="789"
+       id="linearGradient4140"
+       xlink:href="#linearGradient4134"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4127">
+      <stop
+         style="stop-color:#8f2b12;stop-opacity:1;"
+         offset="0"
+         id="stop4129" />
+      <stop
+         style="stop-color:#82461a;stop-opacity:1;"
+         offset="1"
+         id="stop4131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4149"
+       inkscape:collect="always">
+      <stop
+         id="stop4151"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4153"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4566">
+      <stop
+         style="stop-color:#3f3f3f;stop-opacity:1;"
+         offset="0"
+         id="stop4568" />
+      <stop
+         style="stop-color:#625c5c;stop-opacity:1;"
+         offset="1"
+         id="stop4570" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5928-89">
+      <stop
+         id="stop5930-1"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop5932-7"
+         offset="1"
+         style="stop-color:#3a77b9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5928-89"
+       id="linearGradient7127-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-784.11538,94.500053)"
+       x1="816"
+       y1="-92"
+       x2="816"
+       y2="-52" />
+    <linearGradient
+       id="linearGradient8085-6">
+      <stop
+         style="stop-color:#37a12e;stop-opacity:1;"
+         offset="0"
+         id="stop8087-5" />
+      <stop
+         style="stop-color:#54bc43;stop-opacity:1;"
+         offset="1"
+         id="stop8089-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4671-1">
+      <stop
+         id="stop4673-0"
+         offset="0"
+         style="stop-color:#ffec3b;stop-opacity:1;" />
+      <stop
+         id="stop4675-4"
+         offset="1"
+         style="stop-color:#ffe62e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4689-4">
+      <stop
+         id="stop4691-9"
+         offset="0"
+         style="stop-color:#5a9fd4;stop-opacity:1" />
+      <stop
+         id="stop4693-4"
+         offset="1"
+         style="stop-color:#306998;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3988-5-53">
+      <stop
+         id="stop3990-5-9"
+         offset="0"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3992-0-97"
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3960-0">
+      <stop
+         id="stop3962-25"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop3970-72" />
+      <stop
+         id="stop3964-25"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4494"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4498"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4500"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4502"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4504"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,89.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4506"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48"
+       gradientTransform="translate(40,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4538"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4542"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4544"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4546"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4548"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4550"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,129.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(80,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0894009,0,0,1.6666667,-2.6903226,-29)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-1.4000003,-10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0571429,0,0,1.25,-2.4000003,-10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3960"
+       id="linearGradient4620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0305144,0,0,1,-1.2476025,0)"
+       x1="25"
+       y1="45"
+       x2="25"
+       y2="42" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="radialGradient4622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-3e-7,10.875)"
+       cx="40"
+       cy="43.5"
+       fx="40"
+       fy="43.5"
+       r="2" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="radialGradient4624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.75,-1.0000003,10.875)"
+       cx="9"
+       cy="43.5"
+       fx="9"
+       fy="43.5"
+       r="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3988-5"
+       id="linearGradient4626"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.175,0,0,0.175,169.20002,-5.0000326)"
+       x1="144.00006"
+       y1="280.00018"
+       x2="144.00006"
+       y2="40.000172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient4628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(120,0)"
+       x1="24"
+       y1="0"
+       x2="24"
+       y2="48" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Background">
+    <g
+       id="g3942">
+      <rect
+         style="opacity:0.12000002;fill:url(#linearGradient3940);fill-opacity:1;stroke:none"
+         id="rect3985"
+         width="33.771431"
+         height="5"
+         x="7.1142859"
+         y="41" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3937);fill-opacity:1;stroke:none"
+         d="m 40.885716,41.000001 0,5 0.528571,0 c 0.878486,0 1.585715,-1.115 1.585715,-2.5 0,-1.385 -0.707229,-2.5 -1.585715,-2.5 l -0.528571,0 z"
+         id="path3987"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.12000002;fill:url(#radialGradient3934);fill-opacity:1;stroke:none"
+         d="M 6.4866072,41.000001 C 5.6630268,41.000001 5,42.045313 5,43.343751 l 0,0.3125 c 0,1.298439 0.6630268,2.34375 1.4866072,2.34375 l 0.6276786,0 0,-5 -0.6276786,0 z"
+         id="path3989"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="42"
+         x="8.0270262"
+         height="3"
+         width="31.945946"
+         id="rect3938"
+         style="opacity:0.12000002;fill:url(#linearGradient3931);fill-opacity:1;stroke:none" />
+      <path
+         id="rect3940"
+         d="m 40,42 0,3 0.5,0 C 41.331,45 42,44.331 42,43.5 42,42.669 41.331,42 40.5,42 L 40,42 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3928);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect3942"
+         d="m 7.4062497,42 c -0.7790625,0 -1.40625,0.627187 -1.40625,1.40625 l 0,0.1875 c 0,0.779063 0.6271875,1.40625 1.40625,1.40625 l 0.59375,0 0,-3 -0.59375,0 z"
+         style="opacity:0.12000002;fill:url(#radialGradient3925);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.35;color:#bebebe;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,3 8,3 C 7.446,3 7,3.446 7,4 l 0,39 c 0,0.554 0.446,1 1,1 l 32,0 c 0.554,0 1,-0.446 1,-1 L 41,4 C 41,3.446 40.554,3 40,3 z"
+       id="rect3886"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="color:#bebebe;fill:url(#linearGradient3142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 40,4 8,4 8,43 40,43 z"
+       id="rect3882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3893"
+       d="M 40,4 8,4 8,43 40,43 z M 39,5 39,42 9,42 9,5 z"
+       style="opacity:0.40000000000000002;fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:0.40000000000000002;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3144"
+       width="32"
+       height="1"
+       x="8"
+       y="4" />
+    <rect
+       y="42"
+       x="8"
+       height="1"
+       width="32"
+       id="rect3922"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Symbol">
+    <g
+       id="g4662"
+       transform="translate(-40,0)">
+      <path
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman"
+         d="m 67.0625,17.43725 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 2.78125,4.21875 -2.5,3.65625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.559752,0 1.392876,0.01711 1.9375,0.0625 l 0,-0.46875 c -0.695908,-0.01513 -0.96875,-0.446438 -0.96875,-0.71875 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 l 2.15625,-3.1875 2.375,3.625 c 0.03026,0.06051 0.09375,0.110865 0.09375,0.15625 0,0.181541 -0.349477,0.453621 -1,0.46875 l 0,0.46875 c 0.529496,-0.04539 1.643869,-0.0625 2.21875,-0.0625 L 77.5,27.781 l 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 l -3.1875,-4.8125 2.0625,-3.03125 c 0.332826,-0.48411 0.87232,-0.984871 2.21875,-1 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 l 0,0.46875 c 0.605138,0.01513 0.9375,0.339546 0.9375,0.6875 0,0.151284 -0.0191,0.208587 -0.125,0.375 l -1.75,2.53125 -1.9375,-2.90625 c -0.03026,-0.04539 -0.09375,-0.158237 -0.09375,-0.21875 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 c -0.529495,0.04539 -1.64387,0.0625 -2.21875,0.0625 L 67.0625,17.43725 z M 50.78125,17.531 50.5,20.93725 l 0.375,0 c 0.211798,-2.435678 0.434356,-2.9375 2.71875,-2.9375 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.317697,0.06051 0.34375,0.214546 0.34375,0.5625 l 0,7.96875 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.620266,-0.04539 2.179092,-0.0625 2.875,-0.0625 0.695908,0 2.254735,0.01711 2.875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 l 0,-7.96875 c 0,-0.302569 -0.02231,-0.501986 0.25,-0.5625 0.166413,-0.03026 0.58756,-0.03125 0.875,-0.03125 2.284393,0 2.506952,0.501822 2.71875,2.9375 l 0.375,0 -0.28125,-3.40625 -9.25,0 z m 8.1875,3.96875 0,0.46875 0.375,0 c 1.164889,0 1.1875,0.142876 1.1875,0.6875 l 0,7.9375 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 8.71875,0 0.65625,-3.90625 -0.40625,0 c -0.378211,2.329779 -0.71041,3.4375 -3.3125,3.4375 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,-4.03125 1.34375,0 c 1.467458,0 1.65625,0.495333 1.65625,1.78125 l 0.375,0 0,-4.03125 -0.375,0 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,-3.625 c 0,-0.499238 0.03897,-0.59375 0.75,-0.59375 l 1.9375,0 c 2.31465,0 2.726695,0.803397 2.96875,2.90625 l 0.375,0 -0.4375,-3.375 -8.5,0 z"
+         id="path4508"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4447"
+         d="m 67.0625,16.4375 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 2.78125,4.21875 -2.5,3.65625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.559752,0 1.392876,0.01711 1.9375,0.0625 l 0,-0.46875 c -0.695908,-0.01513 -0.96875,-0.446438 -0.96875,-0.71875 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 l 2.15625,-3.1875 2.375,3.625 c 0.03026,0.06051 0.09375,0.110865 0.09375,0.15625 0,0.181541 -0.349477,0.453621 -1,0.46875 l 0,0.46875 c 0.529496,-0.04539 1.643869,-0.0625 2.21875,-0.0625 l 1.96875,0.0625 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 l -3.1875,-4.8125 2.0625,-3.03125 c 0.332826,-0.48411 0.87232,-0.984871 2.21875,-1 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 l 0,0.46875 c 0.605138,0.01513 0.9375,0.339546 0.9375,0.6875 0,0.151284 -0.0191,0.208587 -0.125,0.375 L 72.3125,20.5 70.375,17.59375 c -0.03026,-0.04539 -0.09375,-0.158237 -0.09375,-0.21875 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 C 70.720505,16.48289 69.60613,16.5 69.03125,16.5 L 67.0625,16.4375 z M 50.78125,16.53125 50.5,19.9375 l 0.375,0 C 51.086798,17.501822 51.309356,17 53.59375,17 c 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.317697,0.06051 0.34375,0.214546 0.34375,0.5625 l 0,7.96875 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.620266,-0.04539 2.179092,-0.0625 2.875,-0.0625 0.695908,0 2.254735,0.01711 2.875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 l 0,-7.96875 c 0,-0.302569 -0.02231,-0.501986 0.25,-0.5625 C 56.510163,17.00099 56.93131,17 57.21875,17 c 2.284393,0 2.506952,0.501822 2.71875,2.9375 l 0.375,0 -0.28125,-3.40625 -9.25,0 z m 8.1875,3.96875 0,0.46875 0.375,0 c 1.164889,0 1.1875,0.142876 1.1875,0.6875 l 0,7.9375 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 8.71875,0 0.65625,-3.90625 -0.40625,0 c -0.378211,2.329779 -0.71041,3.4375 -3.3125,3.4375 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,-4.03125 1.34375,0 c 1.467458,0 1.65625,0.495333 1.65625,1.78125 l 0.375,0 0,-4.03125 -0.375,0 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,-3.625 c 0,-0.499238 0.03897,-0.59375 0.75,-0.59375 l 1.9375,0 c 2.31465,0 2.726695,0.803397 2.96875,2.90625 l 0.375,0 -0.4375,-3.375 -8.5,0 z"
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#cccccc;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman" />
+      <path
+         id="path4558"
+         d="m 67.0625,16.4375 0,0.46875 0.3125,0 c 0.832064,0 1.11881,0.107654 1.40625,0.53125 l 0.03125,0.0625 0.21875,0 c 0.331938,0 0.806029,-0.01769 1.28125,-0.03125 -0.01489,-0.03447 -0.03125,-0.06871 -0.03125,-0.09375 0,-0.181542 0.318227,-0.453621 0.96875,-0.46875 l 0,-0.46875 C 70.720505,16.48289 69.60613,16.5 69.03125,16.5 L 67.0625,16.4375 z m 6.1875,0 0,0.46875 c 0.529496,0.01324 0.83436,0.267096 0.90625,0.5625 0.311505,0.01 0.616294,0.0302 0.90625,0.03125 0.357672,-0.31258 0.873481,-0.583199 1.8125,-0.59375 l 0,-0.46875 -1.6875,0.0625 c -0.605138,0 -1.332362,-0.01711 -1.9375,-0.0625 z M 50.78125,16.53125 50.5,19.9375 l 0.09375,0 0.1875,-2.40625 0.71875,0 C 51.871428,17.128058 52.481528,17 53.59375,17 c 0.272312,0 0.661216,9.9e-4 0.8125,0.03125 0.295004,0.05619 0.339036,0.202148 0.34375,0.5 l 1.34375,0 c -0.0014,-0.261644 2.26e-4,-0.444494 0.25,-0.5 C 56.510163,17.00099 56.93131,17 57.21875,17 c 1.112222,0 1.722322,0.128058 2.09375,0.53125 l 0.71875,0 0.1875,2.40625 0.09375,0 -0.28125,-3.40625 -9.25,0 z m 19.875,1.5 c -0.238699,0.09922 -0.375,0.233312 -0.375,0.34375 0,0.06051 0.06349,0.17336 0.09375,0.21875 L 72.3125,21.5 72.65625,21.03125 72.59375,20.9375 74.1875,18.59375 c 0,-0.173977 -0.09127,-0.342261 -0.25,-0.46875 L 72.3125,20.5 70.65625,18.03125 z M 58.96875,20.5 l 0,0.46875 0.375,0 c 1.0336,0 1.170358,0.125442 1.1875,0.53125 l 1.34375,0 c 0.0051,-0.437158 0.07417,-0.53125 0.75,-0.53125 l 1.9375,0 c 1.026983,0 1.664524,0.17161 2.09375,0.53125 l 0.8125,0 0.3125,2.375 0.125,0 -0.4375,-3.375 -7.1875,0 0.03125,0.4375 -0.375,0 C 59.9232,20.773047 59.89003,20.647262 59.875,20.5 l -0.90625,0 z m 13.96875,0.9375 -0.34375,0.5 3.15625,4.78125 1.75,0.0625 0,-0.46875 -0.28125,0 c -0.786679,0 -1.119803,-0.09352 -1.4375,-0.5625 L 72.9375,21.4375 z m -1.71875,0.71875 -2.15625,3.15625 c -0.211798,0.302569 -0.659528,1 -2.1875,1 l 0,0.46875 1.6875,-0.0625 c 0.03607,0 0.0868,-1.45e-4 0.125,0 0.166529,-0.15495 0.30127,-0.300922 0.375,-0.40625 l 0.46875,-0.6875 c -6e-4,-0.0093 0,-0.02226 0,-0.03125 0,-0.136156 0.05036,-0.177337 0.15625,-0.34375 L 71.5,22.5625 71.21875,22.15625 z m -6.34375,1.25 c 0,1.301045 -0.188792,1.78125 -1.65625,1.78125 l -1.34375,0 0,0.46875 1.34375,0 c 0.606405,0 0.972136,0.09125 1.21875,0.28125 0.364197,-0.264508 0.4375,-0.756363 0.4375,-1.53125 l 0.375,0 0,-1 -0.375,0 z M 54.75,25.5625 c 0,0.514367 -0.0053,0.75 -1.59375,0.75 l -0.625,0 0,0.46875 c 0.47875,-0.03503 1.450076,-0.05603 2.21875,-0.0625 0.0024,-0.05095 0,-0.09828 0,-0.15625 l 0,-1 z m 1.34375,0 0,1 c 0,0.05797 -0.0017,0.105298 0,0.15625 0.765165,0.0067 1.715489,0.02796 2.1875,0.0625 l 0,-0.46875 -0.625,0 c -1.588485,0 -1.5625,-0.235633 -1.5625,-0.75 z M 69.8125,26.09375 69.6875,26.25 c -0.10589,0.166413 -0.15625,0.207594 -0.15625,0.34375 0,0.04753 0.01383,0.102095 0.03125,0.15625 0.334979,0.01 0.673963,0.0093 0.9375,0.03125 l 0,-0.46875 c -0.313159,-0.0068 -0.531994,-0.0958 -0.6875,-0.21875 z m 4.09375,0.09375 c -0.156723,0.05962 -0.349804,0.119327 -0.59375,0.125 l 0,0.46875 C 73.536263,26.76207 73.90219,26.75992 74.25,26.75 74.23412,26.72954 74.23032,26.71064 74.21875,26.6875 l -0.3125,-0.5 z M 67.9375,26.875 c -0.01821,0.112168 -0.04425,0.205984 -0.0625,0.3125 0.175657,-0.04959 0.308299,-0.119075 0.4375,-0.1875 l 0.03125,-0.125 -0.40625,0 z m 0.25,0.84375 -0.40625,0.03125 c -0.352936,1.7301 -0.906429,2.5625 -3.15625,2.5625 l -2,0 c -0.711036,0 -0.75,-0.125762 -0.75,-0.625 l 0,1 c 0,0.03707 -6.89e-4,0.06069 0,0.09375 l 4.90625,0 c 0.70807,-0.540212 0.92742,-1.496659 1.15625,-2.90625 l 0.25,0 0,-0.15625 z m -7.65625,1.875 c 0,0.544623 -0.02261,0.71875 -1.1875,0.71875 l -0.375,0 0,0.46875 1.53125,0 c 0.0037,-0.06132 0.03125,-0.112726 0.03125,-0.1875 l 0,-1 z"
+         style="font-size:15.12844849px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;font-family:Latin Modern Roman;-inkscape-font-specification:Latin Modern Roman"
+         inkscape:connector-curvature="0" />
+    </g>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-775.49316"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+       inkscape:label="context"
+       id="context"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans"
+         y="-182.75488"
+         x="-775.49316"
+         sodipodi:role="line"
+         id="tspan3933">apps</tspan></text>
+    <text
+       y="-182.75488"
+       xml:space="preserve"
+       x="-668.01172"
+       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;display:none;enable-background:new;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+       sodipodi:linespacing="125%"
+       inkscape:label="icon-name"
+       id="icon-name"><tspan
+         style="font-size:18px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:DejaVu Sans;-inkscape-font-specification:DejaVu Sans Bold"
+         y="-182.75488"
+         x="-668.01172"
+         sodipodi:role="line"
+         id="tspan3937">texstudio</tspan></text>
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect16x16"
+       width="16"
+       height="16"
+       x="-374.5"
+       y="-62.5"
+       inkscape:label="16x16" />
+    <rect
+       style="fill:#d4d4d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect24x24"
+       width="24"
+       height="24"
+       x="-374.5"
+       y="-102.5"
+       inkscape:label="24x24" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect32x32"
+       width="32"
+       height="32"
+       x="-374.5"
+       y="-150.5"
+       inkscape:label="32x32" />
+    <rect
+       inkscape:label="22x22"
+       y="-101.5"
+       x="-373.5"
+       height="22"
+       width="22"
+       id="rect22x22"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       inkscape:label="48x48"
+       y="17.5"
+       x="-502.5"
+       height="48"
+       width="48"
+       id="rect48x48"
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect256x256"
+       width="256"
+       height="256"
+       x="-774.5"
+       y="-174.5"
+       inkscape:label="256x256" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect64x64"
+       width="64"
+       height="64"
+       x="-502.5"
+       y="-62.5"
+       inkscape:label="64x64" />
+    <rect
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:none;overflow:visible;enable-background:accumulate"
+       id="rect96x96"
+       width="96"
+       height="96"
+       x="-502.5"
+       y="-174.5"
+       inkscape:label="96x96" />
+  </g>
+</svg>


### PR DESCRIPTION
12 new mime types and symbolic links for text-css, text-c, text-csrc, template_source.

![screenshot from 2014-12-22 17 18 20](https://cloud.githubusercontent.com/assets/729732/5527457/8efc4e6c-89fe-11e4-8f22-14c8e4582c13.png)
