### PR TITLE
Add missing 96x96/actions to index.theme

### DIFF
--- a/Faba/index.theme
+++ b/Faba/index.theme
@@ -31,6 +31,11 @@ Context=Actions
 Size=64
 Type=Fixed
 
+[96x96/actions]
+Context=Actions
+Size=96
+Type=Fixed
+
 [256x256/actions]
 Context=Actions
 Size=256


### PR DESCRIPTION
I get the following warning:
`Gtk-WARNING **: Theme directory 96x96/actions of theme Faba has no size field`

I don't know if this is the right way to fix it but this patch stops the warning from appearing!